### PR TITLE
Checkbox to export .vtt + .txt with .html at once

### DIFF
--- a/trans/noScribe.de.yml
+++ b/trans/noScribe.de.yml
@@ -38,7 +38,7 @@ de:
   label_overlapping: 'Überlappende Sprache:'
   label_pause: 'Pausen markieren:'
   label_timestamps: 'Zeitmarken:'
-  label_export_all_formats: 'Export TXT + VTT:'
+  label_export_all_formats: 'TXT + VTT exportieren:'
   
   start_button: Start
   stop_button: Abbruch

--- a/trans/noScribe.de.yml
+++ b/trans/noScribe.de.yml
@@ -38,6 +38,7 @@ de:
   label_overlapping: 'Überlappende Sprache:'
   label_pause: 'Pausen markieren:'
   label_timestamps: 'Zeitmarken:'
+  label_export_all_formats: 'Export TXT + VTT:'
   
   start_button: Start
   stop_button: Abbruch

--- a/trans/noScribe.en.yml
+++ b/trans/noScribe.en.yml
@@ -38,6 +38,7 @@ en:
   label_overlapping: 'Overlapping speech:'
   label_pause: 'Mark pause:'
   label_timestamps: 'Timestamps:'
+  label_export_all_formats: 'Export TXT + VTT:'
   
   
   start_button: Start 

--- a/trans/noScribe.es.yml
+++ b/trans/noScribe.es.yml
@@ -35,6 +35,7 @@ es:
   label_overlapping: 'Discurso solapado:'
   label_pause: 'Marca pausas:'
   label_timestamps: 'Timestamps:'
+  label_export_all_formats: 'Exportar TXT + VTT:'
   
   start_button: Iniciar 
   stop_button: Cancelar

--- a/trans/noScribe.fr.yml
+++ b/trans/noScribe.fr.yml
@@ -35,6 +35,7 @@ fr:
   label_overlapping: 'Chevauchements de parole'
   label_pause: 'Marquer les pauses :'
   label_timestamps: 'Horodatage :'
+  label_export_all_formats: 'Exporter TXT + VTT:'
   
   start_button: "Démarrer"
   stop_button: "Annuler"

--- a/trans/noScribe.it.yml
+++ b/trans/noScribe.it.yml
@@ -35,6 +35,7 @@ it:
   label_overlapping: 'Discorso sovrapposto:'
   label_pause: 'Segna le pause:'
   label_timestamps: 'Timestamps:'
+  label_export_all_formats: 'Esportazione TXT + VTT:'
   
   start_button: Avvia 
   stop_button: Annulla

--- a/trans/noScribe.ja.yml
+++ b/trans/noScribe.ja.yml
@@ -36,6 +36,7 @@ ja:
   label_overlapping: 'オーバーラッピング・スピーチ：'
   label_pause: 'マークはポーズをとる：'
   label_timestamps: 'タイムスタンプ：'
+  label_export_all_formats: 'TXT + VTTをエクスポートします：'
   
   start_button: 開始 
   stop_button: キャンセル

--- a/trans/noScribe.pt.yml
+++ b/trans/noScribe.pt.yml
@@ -36,6 +36,7 @@ pt:
   label_overlapping: 'Sobreposição:'
   label_pause: 'Marcar pausas:'
   label_timestamps: 'Registos temporais:'
+  label_export_all_formats: 'Exportar TXT + VTT:'
   
   start_button: Iniciar 
   stop_button: Cancelar

--- a/trans/noScribe.ru.yml
+++ b/trans/noScribe.ru.yml
@@ -36,6 +36,7 @@ ru:
   label_overlapping: 'Перекрытие речи:'
   label_pause: 'Отметьте паузы:'
   label_timestamps: 'Временные метки:'
+  label_export_all_formats: 'Экспорт TXT + VTT:'
   
   start_button: Старт 
   stop_button: Отмена

--- a/trans/noScribe.zh-CN.yml
+++ b/trans/noScribe.zh-CN.yml
@@ -35,6 +35,7 @@ zh-CN: &defaults
   label_overlapping: '重叠发言：'
   label_pause: '马克停顿了一下：'
   label_timestamps: '时间戳：'
+  label_export_all_formats: '导出 TXT + VTT：'
   
   start_button: 开始 
   stop_button: 取消


### PR DESCRIPTION
Hi!

At the moment it is not possible to generate all 3 available export formats (`.html`, `.txt` and `.vtt`) at once - the transcription pipeline has to run individually to generate one of these 3 export formats, which is quite costly (in time and computation) if you want to generate multiple export formats at once (as I wanted to do).

To fix this, I implemented a checkbox `check_box_export_all_formats` to toggle the additional output of `.vtt` and `.txt` files. The additional output files are stored in the same folder the user has chosen for their main transcription file. I have also included translations for the new checkbox.

To give the new checkbox a bit more space in the UI, I increased the height of `self.geometry` by 5px.

<img width="1095" alt="noScribe_update" src="https://github.com/user-attachments/assets/180423ba-75b8-49cf-bba8-878c9f174f17">
