### PR TITLE
Update noScribe.zh-CN.yml translations

### DIFF
--- a/trans/noScribe.zh-CN.yml
+++ b/trans/noScribe.zh-CN.yml
@@ -18,12 +18,14 @@ zh-CN: &defaults
     祝您使用愉快！
 
   setup_message: '首次运行：完成设置...'
+  new_release: 'noScribe的新版本 (%{v})现已发布：'
+  new_release_download: '下载：'
 
   # 用户界面元素
   label_audio_file: '音频文件：'
   label_audio_file_name: <选择文件>
   
-  label_transcript_file: '保存转录为：'
+  label_transcript_file: '保存转录文件为：'
   label_transcript_file_name: <选择文件名> 
 
   label_start: '开始（hh:mm:ss）：'
@@ -34,11 +36,15 @@ zh-CN: &defaults
   label_whisper_model: '人工智能模型：'
   label_add_custom_models: '添加人工智能模型...'  
   label_overlapping: '重叠发言：'
-  label_pause: '马克停顿了一下：'
+  label_pause: '标记停顿：'
   label_timestamps: '时间戳：'
+  label_disfluencies: '语言停顿：'
   
   start_button: 开始 
   stop_button: 取消
+  editor_button: 编辑器
+
+  overall_progress: '总进度：'
 
   # 日志信息
   log_transcript_filename: '转录文件名：'
@@ -50,6 +56,10 @@ zh-CN: &defaults
   start_canceling: '正在取消...（请稍候）'
   start_transcription: '正在转录...'
   loading_whisper: '加载whisper中'
+  start_transcription: '转录...'
+  loading_whisper: '正在加载whisper'
+  vad: '语音活动检测...'
+  
   transcription_finished: '转录完成。' 
   transcription_saved: '已保存至'
   trancription_time: '时长：%{duration}分钟'
@@ -60,7 +70,7 @@ zh-CN: &defaults
   err_options: '选项错误'
   err_no_audio_file: '错误：请选择音频文件。'
   err_no_transcript_file: '错误：请选择完成的转录文件名。'
-  err_ffmpeg: 'ffmpeg返回错误'
+  err_ffmpeg: 'ffmpeg返回了一个错误'
   err_converting_audio: '步骤1中的音频转换错误。'
   err_identifying_speakers: '步骤2中的说话人识别错误。'
   transcription_canceled: '是否确认取消转录？'   
@@ -69,9 +79,12 @@ zh-CN: &defaults
   err_transcription: '步骤3中的转录错误。'
   rescue_saving: '保存至原始文件名失败。已保存至此文件：%{file}'
   rescue_saving_failed: '错误：保存至原始文件名失败。备用文件名已存在。程序将退出。（请确保转录文件未在Word中打开！）'
+  err_noScribeEdit_not_found: '错误：找不到noScribe编辑器。'
+  err_vtt_invalid_options: '警告：VTT文件不支持“重叠发言”、“标记停顿”和“时间戳”选项。'
+  err_editor_invalid_format: '编辑器只能用于html文件。你仍然要启动它吗？'
 
   # 文档内容
-  doc_header: '使用noScribe转录版本：%{version}'
+  doc_header: '使用noScribe %{version} 版本转录'
   doc_header_audio: '音频文件：%{file}'
   pause_minutes: '(%{minutes} 分钟 暂停)'
   pause_seconds: '(%{seconds} 秒暂停)'


### PR DESCRIPTION
- Fixed somewhat confusing mistake on `label_pause` (original translation literally said the person Mark paused)
- Added some missing translations
- Minor fixes