### PR TITLE
Add manual Linux installation with conda

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ ported by [Eckhard Kadasch](https://github.com/eckhrd) and [Florian Dobener](htt
     ```
 
 - **Manual installation from source with conda:**
+  
+Optional: to get the Intel-accelerated Python and pytorch for CPU, you must first install the OneAPI base toolkit
+
+https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit-download.html?packages=oneapi-toolkit&oneapi-toolkit-os=linux&oneapi-lin=apt
+
     ```shell
     # release ( must be > 0.6 in order to include the latest fixes for linux!)
     NOS_REL=0.6
@@ -125,6 +130,9 @@ ported by [Eckhard Kadasch](https://github.com/eckhrd) and [Florian Dobener](htt
 
     # Create the conda environment and install requirements
     conda env create --file environments/requirements_linux.yaml
+
+    # Alternative: Create the conda environment and install Intel Python requirements
+    conda env create --file environments/requirements_intel_cpu.yaml
     
     # Activate the environment
     conda activate noscribe

--- a/README.md
+++ b/README.md
@@ -106,6 +106,39 @@ ported by [Eckhard Kadasch](https://github.com/eckhrd) and [Florian Dobener](htt
     python3 ./noScribe.py
     ```
 
+- **Manual installation from source with conda:**
+    ```shell
+    # release ( must be > 0.6 in order to include the latest fixes for linux!)
+    NOS_REL=0.6
+    wget https://github.com/kaixxx/noScribe/archive/refs/tags/v${NOS_REL).tar.gz
+    tar xvz -f v${NOS_REL).tar.gz
+    cd noScribe-${NOS_REL)/  # from here on all happens in this directory
+
+    # alternative: current main branch
+    wget -O noScribe-main.zip https://github.com/kaixxx/noScribe/archive/refs/heads/main.zip
+    unzip noScribe-main.zip
+    cd noScribe-main # from here on all happens in this directory
+
+    # install noScribeEdit
+    rm -rf noScribeEdit/
+    git clone https://github.com/kaixxx/noScribeEditor.git noScribeEdit
+
+    # Create the conda environment and install requirements
+    conda env create --file environments/requirements_linux.yaml
+    
+    # Activate the environment
+    conda activate noscribe
+
+    # models/precise
+    # this assumes you have git large file support enabled: apt install git-lfs
+    rm -rf models/precise
+    git clone https://huggingface.co/mobiuslabsgmbh/faster-whisper-large-v3-turbo models/precise
+    for f in config.json  model.bin  preprocessor_config.json  tokenizer.json  vocabulary.json; do wget -O models/fast/$f "https://huggingface.co/mukowaty/faster-whisper-int8/resolve/main/faster-whisper-large-v3-turbo-int8/${f}?download=true"; done
+
+    # run
+    python3 ./noScribe.py
+    ```
+
 ### Old versions:
 - [https://drive.switch.ch/index.php/s/EIVup04qkSHb54j](https://drive.switch.ch/index.php/s/EIVup04qkSHb54j) 
 

--- a/environments/requirements_intel_cpu.yaml
+++ b/environments/requirements_intel_cpu.yaml
@@ -1,0 +1,41 @@
+#This defines an environment to execute Intel-accelerated Python on CPU
+#Intel reserves the cpu-only distro of pytorch to a separate pip index
+name: noscribe_intel_cpu # This will become the name of your environment
+channels:
+    - https://software.repos.intel.com/python/conda
+    - defaults
+dependencies: # The list of packages to include in your environment
+    - python=3.12
+    - python_abi
+    - numpy 
+    - scipy 
+    - level-zero  #Intel Level-zero library - should be part of OneAPI but isn't
+    - scikit-learn 
+    - scikit-learn-intelex 
+    - dpnp 
+    - dpctl 
+    - tbb4py 
+    - smp 
+    - mpi4py
+    - deepspeed 
+    - modin-all 
+    - onnxruntime
+    - appdirs
+    - Pillow
+    - pyinstaller
+    - PyYAML
+    - pip # Install pip in your environment
+    - pip: # Include pip dependencies last
+        - --index-url https://download.pytorch.org/whl/cpu
+        #- --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/cpu/us/ 
+        - --extra-index-url https://pypi.org/simple/
+        - torch>=2.7.1
+        - torchaudio
+        - intel-extension-for-pytorch
+        - AdvancedHTMLParser
+        - customtkinter
+        - faster-whisper
+        - pyannote.audio>=3.3.2
+        - python-i18n
+
+

--- a/environments/requirements_intel_cpu.yaml
+++ b/environments/requirements_intel_cpu.yaml
@@ -1,4 +1,5 @@
 #This defines an environment to execute Intel-accelerated Python on CPU
+# Prerequisite:  Intel Oneapi base toolkit
 #Intel reserves the cpu-only distro of pytorch to a separate pip index
 name: noscribe_intel_cpu # This will become the name of your environment
 channels:

--- a/environments/requirements_linux.yaml
+++ b/environments/requirements_linux.yaml
@@ -1,0 +1,19 @@
+# Conda environment file for both noScribe and noScribeEdit
+name: noscribe
+dependencies: # The list of packages to include in your environment
+    - python=3.11 # To accomodate the Intel AI tools.  3.12 is the recommended version
+    - python_abi
+    - torchaudio
+    - appdirs
+    - Pillow
+    - pyinstaller
+    - PyYAML
+    - qtawesome
+    - pip # Install pip in your environment
+    - pip: # pip dependencies that are not in conda default repos
+        - AdvancedHTMLParser
+        - customtkinter
+        - faster-whisper
+        - pyannote.audio>=3.3.2
+        - python-i18n
+        - pyqt6


### PR DESCRIPTION
This adds a conda requirements file and amends the README to show how to use it.

I made this to be able to use the Intel accelerated Python and Torch libraries, and it seems easier than dealing directly with pip and venv.

This relies on Python 3.11, (mini)conda and pip.
