### PR TITLE
Add entry scripts and platform PyInstaller specs

### DIFF
--- a/pyinstaller/entry/cli_entry.py
+++ b/pyinstaller/entry/cli_entry.py
@@ -1,0 +1,23 @@
+import sys
+from noScribe import parse_cli_args, run_cli_mode, show_available_models, App
+
+def run_cli(argv):
+    sys.argv = [sys.argv[0]] + list(argv)
+    args = parse_cli_args()
+    if args.help_models:
+        show_available_models()
+        return 0
+    if args.audio_file and args.output_file:
+        return run_cli_mode(args)
+    elif args.audio_file or args.output_file:
+        print("Error: Both audio_file and output_file are required for CLI mode.")
+        print("Use --help for usage information.")
+        return 1
+    else:
+        app = App()
+        app.mainloop()
+        return 0
+
+if __name__ == "__main__":
+    code = run_cli(sys.argv[1:])
+    raise SystemExit(code if isinstance(code, int) else 0)

--- a/pyinstaller/entry/gui_entry.py
+++ b/pyinstaller/entry/gui_entry.py
@@ -1,0 +1,8 @@
+from noScribe import App
+
+def run_gui():
+    app = App()
+    app.mainloop()
+
+if __name__ == "__main__":
+    run_gui()

--- a/pyinstaller/noScribe_all_linux.spec
+++ b/pyinstaller/noScribe_all_linux.spec
@@ -1,0 +1,97 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+import sys
+from pathlib import Path
+from PyInstaller.utils.hooks import collect_data_files, copy_metadata
+
+BASE = Path(__file__).resolve().parent.parent
+
+
+def common_datas():
+    datas = []
+    for rel in ["noScribeEdit", "trans", "models"]:
+        if (BASE / rel).exists():
+            datas.append((str(BASE / rel), rel))
+    for rel in ["prompt.yml", "graphic_sw.png", "noScribeLogo.ico"]:
+        if (BASE / rel).exists():
+            datas.append((str(BASE / rel), "."))
+    for pattern in ["README*", "LICENSE*"]:
+        for path in BASE.glob(pattern):
+            datas.append((str(path), "."))
+    datas += collect_data_files("customtkinter")
+    datas += copy_metadata("AdvancedHTMLParser")
+    if sys.platform.startswith(("win", "linux")):
+        datas += collect_data_files("faster_whisper")
+        datas += copy_metadata("faster_whisper")
+    return datas
+
+
+def platform_binaries():
+    binaries = []
+    ffmpeg = BASE / "ffmpeg-linux-x86_64"
+    if ffmpeg.exists():
+        binaries.append((str(ffmpeg), "ffmpeg-linux-x86_64"))
+    return binaries
+
+
+block_cipher = None
+
+a = Analysis(
+    [str(BASE / "pyinstaller" / "entry" / "gui_entry.py"),
+     str(BASE / "pyinstaller" / "entry" / "cli_entry.py")],
+    pathex=[str(BASE)],
+    binaries=platform_binaries(),
+    datas=common_datas(),
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+gui = EXE(
+    pyz,
+    a.scripts[0],
+    [],
+    exclude_binaries=True,
+    name="noScribe",
+    console=False,
+    icon=str(BASE / "noScribeLogo.ico"),
+)
+
+cli = EXE(
+    pyz,
+    a.scripts[1],
+    [],
+    exclude_binaries=True,
+    name="noScribe-cli",
+    console=True,
+    icon=str(BASE / "noScribeLogo.ico"),
+)
+
+coll_gui = COLLECT(
+    gui,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name="noScribe",
+)
+
+coll_cli = COLLECT(
+    cli,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name="noScribe-cli",
+)

--- a/pyinstaller/noScribe_all_macos.spec
+++ b/pyinstaller/noScribe_all_macos.spec
@@ -1,0 +1,93 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+from pathlib import Path
+from PyInstaller.utils.hooks import collect_data_files, copy_metadata
+
+BASE = Path(__file__).resolve().parent.parent
+
+
+def common_datas():
+    datas = []
+    for rel in ["noScribeEdit", "trans", "models"]:
+        if (BASE / rel).exists():
+            datas.append((str(BASE / rel), rel))
+    for rel in ["prompt.yml", "graphic_sw.png", "noScribeLogo.ico"]:
+        if (BASE / rel).exists():
+            datas.append((str(BASE / rel), "."))
+    for pattern in ["README*", "LICENSE*"]:
+        for path in BASE.glob(pattern):
+            datas.append((str(path), "."))
+    datas += collect_data_files("customtkinter")
+    datas += copy_metadata("AdvancedHTMLParser")
+    return datas
+
+
+def platform_binaries():
+    binaries = []
+    ffmpeg = BASE / "ffmpeg" / "ffmpeg"
+    if ffmpeg.exists():
+        binaries.append((str(ffmpeg), "ffmpeg"))
+    return binaries
+
+
+block_cipher = None
+
+a = Analysis(
+    [str(BASE / "pyinstaller" / "entry" / "gui_entry.py"),
+     str(BASE / "pyinstaller" / "entry" / "cli_entry.py")],
+    pathex=[str(BASE)],
+    binaries=platform_binaries(),
+    datas=common_datas(),
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+gui = EXE(
+    pyz,
+    a.scripts[0],
+    [],
+    exclude_binaries=True,
+    name="noScribe",
+    console=False,
+    icon=str(BASE / "noScribeLogo.ico"),
+)
+
+cli = EXE(
+    pyz,
+    a.scripts[1],
+    [],
+    exclude_binaries=True,
+    name="noScribe-cli",
+    console=True,
+    icon=str(BASE / "noScribeLogo.ico"),
+)
+
+coll_gui = COLLECT(
+    gui,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name="noScribe",
+)
+
+app = BUNDLE(coll_gui, name="noScribe.app", icon=str(BASE / "noScribeLogo.ico"))
+
+coll_cli = COLLECT(
+    cli,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name="noScribe-cli",
+)

--- a/pyinstaller/noScribe_all_windows.spec
+++ b/pyinstaller/noScribe_all_windows.spec
@@ -1,0 +1,97 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+import sys
+from pathlib import Path
+from PyInstaller.utils.hooks import collect_data_files, copy_metadata
+
+BASE = Path(__file__).resolve().parent.parent
+
+
+def common_datas():
+    datas = []
+    for rel in ["noScribeEdit", "trans", "models"]:
+        if (BASE / rel).exists():
+            datas.append((str(BASE / rel), rel))
+    for rel in ["prompt.yml", "graphic_sw.png", "noScribeLogo.ico"]:
+        if (BASE / rel).exists():
+            datas.append((str(BASE / rel), "."))
+    for pattern in ["README*", "LICENSE*"]:
+        for path in BASE.glob(pattern):
+            datas.append((str(path), "."))
+    datas += collect_data_files("customtkinter")
+    datas += copy_metadata("AdvancedHTMLParser")
+    if sys.platform.startswith(("win", "linux")):
+        datas += collect_data_files("faster_whisper")
+        datas += copy_metadata("faster_whisper")
+    return datas
+
+
+def platform_binaries():
+    binaries = []
+    ffmpeg = BASE / "ffmpeg.exe"
+    if ffmpeg.exists():
+        binaries.append((str(ffmpeg), "ffmpeg.exe"))
+    return binaries
+
+
+block_cipher = None
+
+a = Analysis(
+    [str(BASE / "pyinstaller" / "entry" / "gui_entry.py"),
+     str(BASE / "pyinstaller" / "entry" / "cli_entry.py")],
+    pathex=[str(BASE)],
+    binaries=platform_binaries(),
+    datas=common_datas(),
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+gui = EXE(
+    pyz,
+    a.scripts[0],
+    [],
+    exclude_binaries=True,
+    name="noScribe",
+    console=False,
+    icon=str(BASE / "noScribeLogo.ico"),
+)
+
+cli = EXE(
+    pyz,
+    a.scripts[1],
+    [],
+    exclude_binaries=True,
+    name="noScribe-cli",
+    console=True,
+    icon=str(BASE / "noScribeLogo.ico"),
+)
+
+coll_gui = COLLECT(
+    gui,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name="noScribe",
+)
+
+coll_cli = COLLECT(
+    cli,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name="noScribe-cli",
+)


### PR DESCRIPTION
## Summary
- Add GUI and CLI entry scripts for PyInstaller builds
- Provide Windows, macOS, and Linux spec files generating both console and GUI executables from shared analysis

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_b_689b9dd24c248322861ba96061294487