### PR TITLE
Add missing translation strings

### DIFF
--- a/trans/noScribe.de.yml
+++ b/trans/noScribe.de.yml
@@ -40,15 +40,19 @@ de:
   label_pause: 'Pausen markieren:'
   label_timestamps: 'Zeitmarken:'
   label_disfluencies: 'Füllworte:'
-  
+
   start_button: Start
   stop_button: Abbrechen
+  editor_button: Editor
 
   overall_progress: 'Fortschritt insgesamt: '
 
   # log messages
   log_transcript_filename: 'Transkript-Dateiname: '
   log_audio_file_selected: 'Gewählte Audiodatei: '
+  queue_start: '=== Warteschlange wird gestartet ==='
+  queue_start_jobs: 'Bearbeite %{total} Transkriptionsauftrag/-aufträge'
+  start_job: 'Starte Auftrag: %{audio_file}'
   start_audio_conversion: 'Audioumwandlung...'
   audio_conversion_finished: 'Umwandlung fertig.'
   start_identifiying_speakers: 'Sprecher:innen identifizieren...'
@@ -56,12 +60,17 @@ de:
   start_canceling: 'Abbrechen läuft...'
   start_transcription: 'Transkription...'
   loading_whisper: 'Whisper laden'
-  transcription_finished: 'Transkription beendet.' 
+  vad: 'Sprachaktivitätserkennung...'
+  transcription_finished: 'Transkription beendet.'
   transcription_saved: 'Gespeichert unter: '
   trancription_time: 'Dauer: %{duration} Minuten'
+  queue_complete: '=== Warteschlangenverarbeitung abgeschlossen ==='
+  total_jobs: 'Aufträge insgesamt: %{total}'
+  completed: 'Abgeschlossen: %{finished}'
+  failed: 'Fehlgeschlagen: %{errors}'
 
   # Error messages
-  err_setup: 'Während des Einrichtung ist ein Fehler aufgetreten. Bitte die Internetverbindung prüfen.'
+  err_setup: 'Während der Einrichtung ist ein Fehler aufgetreten. Bitte die Internetverbindung prüfen.'
   err_invalid_time_string: 'Das ist keine korrekte Zeitangabe: "%{time}"'
   err_options: 'Fehler in den Optionen'
   err_no_audio_file: 'Fehler: Bitte eine Audiodatei wählen.'
@@ -75,8 +84,10 @@ de:
   err_transcription: 'Fehler im 3. Schritt - Transkription'
   rescue_saving: 'Beim Speichern unter dem ursprünglichen Dateinamen ist ein Fehler aufgetreten. Stattdessen wurde das Transkript in dieser Datei gesichert: %{file}'
   rescue_saving_failed: 'Fehler: Beim Speichern unter dem ursprünglichen Dateinamen ist ein Fehler aufgetreten. Der alternative Dateiname existiert ebenso bereits. Die Transkription wird beendet. (Das Transkript darf nicht bereits in Word geöffnet sein!)'
-  err_noScribeEdit_not_found: 'Fehler: Der noScribe-Editor konnte nicht gefunden werden.' 
+  err_noScribeEdit_not_found: 'Fehler: Der noScribe-Editor konnte nicht gefunden werden.'
   err_vtt_invalid_options: 'Achtung: Die Optionen "Überlappende Sprache", "Pausen markieren" und "Zeitmarken" werden bei der VTT-Ausgabe nicht unterstützt.'
+  err_editor_invalid_format: 'Der Editor kann nur mit html-Dateien verwendet werden. Trotzdem starten?'
+  err_invalid_model: 'Ignorierter doppelter Name für whisper-Modell: "%{model_name}"'
 
 
   # Doc contents

--- a/trans/noScribe.es.yml
+++ b/trans/noScribe.es.yml
@@ -18,6 +18,8 @@ es:
     ¡Disfruta!
 
   setup_message: 'Primera ejecución: Completa la configuración...'
+  new_release: 'Hay una nueva versión de noScribe disponible (%{v}):'
+  new_release_download: 'Descargar: '
 
   # Elementos de la interfaz de usuario
   label_audio_file: 'Archivo de audio:'
@@ -30,29 +32,40 @@ es:
   label_stop: 'Fin (hh:mm:ss): ' 
 
   label_language: 'Idioma:'
-  label_speaker: 'Detección de oradores:'
+  label_speaker: 'Detección de hablantes:'
   label_whisper_model: 'Modelo:'
   label_add_custom_models: 'Añadir modelo AI...'
   label_overlapping: 'Discurso solapado:'
-  label_pause: 'Marca pausas:'
-  label_timestamps: 'Timestamps:'
+  label_pause: 'Marcar pausas:'
+  label_timestamps: 'Marcas de tiempo:'
+  label_disfluencies: 'Disfluencias:'
   
-  start_button: Iniciar 
+  start_button: Iniciar
   stop_button: Cancelar
+  editor_button: Editor
 
+  overall_progress: 'Progreso total: '
   # Mensajes de registro
   log_transcript_filename: 'Nombre de archivo de transcripción: '
   log_audio_file_selected: 'Archivo de audio seleccionado: '
+  queue_start: '=== Iniciando cola ==='
+  queue_start_jobs: 'Procesando %{total} trabajo(s) de transcripción'
+  start_job: 'Iniciando trabajo: %{audio_file}'
   start_audio_conversion: 'Convirtiendo audio...'
   audio_conversion_finished: 'Conversión de audio finalizada'
   start_identifiying_speakers: 'Identificación de oradores...'
   loading_pyannote: 'Cargando pyannote'
   start_canceling: 'Cancelando... (por favor, espera un momento)'
   start_transcription: 'Transcribiendo...'
-  loading_whisper: 'Cargando whisper'
-  transcription_finished: 'Transcripción finalizada.' 
-  transcription_saved: 'Guardado en '
+  loading_whisper: 'Cargando Whisper'
+  vad: 'Detección de actividad de voz...'
+  transcription_finished: 'Transcripción finalizada.'
+  transcription_saved: 'Guardado en: '
   trancription_time: 'Duración: %{duration} minutos'
+  queue_complete: '=== Procesamiento de la cola completado ==='
+  total_jobs: 'Trabajos totales: %{total}'
+  completed: 'Completados: %{finished}'
+  failed: 'Fallidos: %{errors}'
 
   # Mensajes de error
   err_setup: 'Se produjo un error durante la configuración. Verifica tu conexión a Internet y reinicia el programa.'
@@ -69,6 +82,10 @@ es:
   err_transcription: 'Error en el paso 3: transcripción'
   rescue_saving: 'Fallo al guardar con el nombre de archivo original. Guardado en este archivo en su lugar: %{file}'
   rescue_saving_failed: 'Error: Fallo al guardar con el nombre de archivo original. El nombre de archivo alternativo también existe. Tengo que salir. (¡Asegúrate de que tu transcripción no esté abierta en Word!)'
+  err_noScribeEdit_not_found: 'Error: No se pudo encontrar el editor de noScribe.'
+  err_vtt_invalid_options: 'Advertencia: Las opciones "Discurso solapado", "Marcar pausas" y "Marcas de tiempo" no están soportadas en archivos VTT.'
+  err_editor_invalid_format: 'El editor solo puede usarse con archivos HTML. ¿Deseas iniciarlo de todas formas?'
+  err_invalid_model: 'Nombre duplicado ignorado para el modelo whisper: "%{model_name}"'
 
   # Contenido del documento
   doc_header: 'Transcrito con noScribe ver. %{version}'

--- a/trans/noScribe.fr.yml
+++ b/trans/noScribe.fr.yml
@@ -18,6 +18,8 @@ fr:
     Profitez-en !
 
   setup_message: "Première exécution : Termine la configuration..."
+  new_release: "Une nouvelle version de noScribe est disponible (%{v}) :"
+  new_release_download: "Télécharger : "
 
   # Éléments de l'interface utilisateur
   label_audio_file: "Fichier audio :"
@@ -33,26 +35,37 @@ fr:
   label_speaker: "Détection des locuteurs :"
   label_whisper_model: "Modèle :"
   label_add_custom_models: "Ajouter un modèle d'IA..."
-  label_overlapping: 'Chevauchements de parole'
+  label_overlapping: 'Chevauchement de parole :'
   label_pause: 'Marquer les pauses :'
   label_timestamps: 'Horodatage :'
+  label_disfluencies: 'Mots de remplissage :'
   
   start_button: "Démarrer"
   stop_button: "Annuler"
+  editor_button: "Éditeur"
 
+  overall_progress: 'Progression totale : '
   # Messages de journalisation
   log_transcript_filename: "Nom du fichier de transcription : "
   log_audio_file_selected: "Fichier audio sélectionné : "
+  queue_start: '=== Démarrage de la file d'attente ==='
+  queue_start_jobs: 'Traitement de %{total} tâche(s) de transcription'
+  start_job: 'Démarrage de la tâche : %{audio_file}'
   start_audio_conversion: "Conversion audio en cours..."
   audio_conversion_finished: "Conversion audio terminée"
   start_identifiying_speakers: "Identification des locuteurs en cours..."
   loading_pyannote: "Chargement de pyannote"
   start_canceling: "Annulation en cours... (veuillez patienter un instant)"
   start_transcription: "Transcription en cours..."
-  loading_whisper: "Chargement de whisper"
-  transcription_finished: "Transcription terminée." 
-  transcription_saved: "Enregistré sous "
+  loading_whisper: "Chargement de Whisper"
+  vad: 'Détection d\'activité vocale...'
+  transcription_finished: "Transcription terminée."
+  transcription_saved: "Enregistré sous : "
   trancription_time: "Durée : %{duration} minutes"
+  queue_complete: '=== Traitement de la file d\'attente terminé ==='
+  total_jobs: 'Tâches totales : %{total}'
+  completed: 'Terminées : %{finished}'
+  failed: 'Échouées : %{errors}'
 
   # Messages d'erreur
   err_setup: "Une erreur s'est produite pendant la configuration. Vérifiez votre connexion internet et redémarrez le programme."
@@ -69,6 +82,10 @@ fr:
   err_transcription: "Erreur à l'étape 3 - transcription"
   rescue_saving: "Échec de l'enregistrement sous le nom de fichier d'origine. Enregistré sous ce fichier à la place : %{file}"
   rescue_saving_failed: "Erreur : Échec de l'enregistrement sous le nom de fichier d'origine. Le nom de fichier alternatif existe également. Je dois quitter. (Assurez-vous que votre transcription n'est pas déjà ouverte dans Word !)"
+  err_noScribeEdit_not_found: "Erreur : Impossible de trouver l'éditeur noScribe."
+  err_vtt_invalid_options: 'Avertissement : les options "Chevauchements de parole", "Marquer les pauses" et "Horodatage" ne sont pas prises en charge dans les fichiers VTT.'
+  err_editor_invalid_format: "L'éditeur ne peut être utilisé qu'avec des fichiers HTML. Voulez-vous quand même le lancer ?"
+  err_invalid_model: 'Nom en double ignoré pour le modèle whisper : "%{model_name}"'
 
   # Contenu du document
   doc_header: "Transcrit avec noScribe vers. %{version}"

--- a/trans/noScribe.it.yml
+++ b/trans/noScribe.it.yml
@@ -18,6 +18,8 @@ it:
     Buon divertimento!
 
   setup_message: 'Prima esecuzione: Completa la configurazione...'
+  new_release: 'È disponibile una nuova versione di noScribe (%{v}):'
+  new_release_download: 'Scarica: '
 
   # Elementi dell'interfaccia utente
   label_audio_file: 'File audio:'
@@ -30,29 +32,40 @@ it:
   label_stop: 'Fine (hh:mm:ss): ' 
 
   label_language: 'Lingua:'
-  label_speaker: 'Rilevamento degli speaker:'
+  label_speaker: 'Rilevamento dei parlanti:'
   label_whisper_model: 'Modello:'
   label_add_custom_models: 'Aggiungi modello AI...'
   label_overlapping: 'Discorso sovrapposto:'
   label_pause: 'Segna le pause:'
-  label_timestamps: 'Timestamps:'
+  label_timestamps: 'Marcatori temporali:'
+  label_disfluencies: 'Disfluenze:'
   
-  start_button: Avvia 
+  start_button: Avvia
   stop_button: Annulla
+  editor_button: Editor
 
+  overall_progress: 'Progresso totale: '
   # Messaggi di log
   log_transcript_filename: 'Nome file trascrizione: '
   log_audio_file_selected: 'File audio selezionato: '
+  queue_start: '=== Avvio della coda ==='
+  queue_start_jobs: 'Elaborazione di %{total} attività di trascrizione'
+  start_job: 'Avvio attività: %{audio_file}'
   start_audio_conversion: 'Conversione audio in corso...'
   audio_conversion_finished: 'Conversione audio completata'
-  start_identifiying_speakers: 'Identificazione degli speaker in corso...'
+  start_identifiying_speakers: 'Identificazione dei parlanti in corso...'
   loading_pyannote: 'Caricamento di pyannote'
   start_canceling: 'Annullamento in corso... (attendere un secondo)'
   start_transcription: 'Trascrizione in corso...'
-  loading_whisper: 'Caricamento di whisper'
-  transcription_finished: 'Trascrizione completata.' 
-  transcription_saved: 'Salvato in '
+  loading_whisper: 'Caricamento di Whisper'
+  vad: 'Rilevamento dell\'attività vocale...'
+  transcription_finished: 'Trascrizione completata.'
+  transcription_saved: 'Salvato in: '
   trancription_time: 'Durata: %{duration} minuti'
+  queue_complete: '=== Elaborazione della coda completata ==='
+  total_jobs: 'Attività totali: %{total}'
+  completed: 'Completate: %{finished}'
+  failed: 'Fallite: %{errors}'
 
   # Messaggi di errore
   err_setup: 'Si è verificato un errore durante la configurazione. Controlla la tua connessione internet e riavvia il programma.'
@@ -62,13 +75,17 @@ it:
   err_no_transcript_file: 'Errore: scegli un nome per la trascrizione finale.'
   err_ffmpeg: 'ffmpeg ha restituito un errore'
   err_converting_audio: 'Errore nella fase 1 - conversione audio.'
-  err_identifying_speakers: 'Errore nella fase 2 - identificazione degli speaker.'
-  transcription_canceled: 'Vuoi davvero annullare la trascrizione?'   
-  err_user_cancelation: 'Processo annullato dall utente.'
+  err_identifying_speakers: 'Errore nella fase 2 - identificazione dei parlanti.'
+  transcription_canceled: 'Vuoi davvero annullare la trascrizione?'
+  err_user_cancelation: 'Processo annullato dall\'utente.'
   err_whisper_main: 'Whisper terminato con il codice di errore %{e}'
   err_transcription: 'Errore nella fase 3 - trascrizione'
   rescue_saving: 'Salvataggio con il nome originale non riuscito. Salvato invece in questo file: %{file}'
   rescue_saving_failed: 'Errore: salvataggio con il nome originale non riuscito. Il nome alternativo esiste già. Il programma deve essere chiuso. (Assicurati che la trascrizione non sia già aperta in Word!)'
+  err_noScribeEdit_not_found: 'Errore: impossibile trovare l\'editor di noScribe.'
+  err_vtt_invalid_options: 'Avviso: le opzioni "Discorso sovrapposto", "Segna le pause" e "Marcatori temporali" non sono supportate nei file VTT.'
+  err_editor_invalid_format: 'L\'editor può essere utilizzato solo con file HTML. Vuoi avviarlo comunque?'
+  err_invalid_model: 'Nome duplicato ignorato per il modello whisper: "%{model_name}"'
 
   # Contenuti del documento
   doc_header: 'Trascritto con noScribe vers. %{version}'

--- a/trans/noScribe.ja.yml
+++ b/trans/noScribe.ja.yml
@@ -19,6 +19,8 @@ ja:
     お楽しみください！
 
   setup_message: '初回実行：セットアップを完了してください...'
+  new_release: 'noScribe の新しいバージョンが利用可能です (%{v}):'
+  new_release_download: 'ダウンロード: '
 
   # UI要素
   label_audio_file: '音声ファイル：'
@@ -34,45 +36,60 @@ ja:
   label_speaker: '話者検出：'
   label_whisper_model: 'モデル：'
   label_add_custom_models: 'AIモデルを追加...'
-  label_overlapping: 'オーバーラッピング・スピーチ：'
-  label_pause: 'マークはポーズをとる：'
+  label_overlapping: '重複発話：'
+  label_pause: 'ポーズをマーク：'
   label_timestamps: 'タイムスタンプ：'
-  
-  start_button: 開始 
+  label_disfluencies: 'フィラー：'
+
+  start_button: 開始
   stop_button: キャンセル
+  editor_button: エディター
+  overall_progress: '全体の進行状況：'
 
   # ログメッセージ
   log_transcript_filename: '転写ファイル名：'
   log_audio_file_selected: '選択された音声ファイル：'
+  queue_start: '=== キューを開始 ==='
+  queue_start_jobs: '%{total} 個の転写ジョブを処理中'
+  start_job: 'ジョブを開始: %{audio_file}'
   start_audio_conversion: '音声の変換を開始中...'
   audio_conversion_finished: '音声の変換が完了しました'
   start_identifiying_speakers: '話者の識別を開始中...'
   loading_pyannote: 'pyannoteの読み込み中'
   start_canceling: 'キャンセル中...（しばらくお待ちください）'
   start_transcription: '転写を開始中...'
-  loading_whisper: 'whisperの読み込み中'
-  transcription_finished: '転写が完了しました。' 
-  transcription_saved: '%{file}に保存されました'
+  loading_whisper: 'Whisperの読み込み中'
+  vad: '音声活動検出...'
+  transcription_finished: '転写が完了しました。'
+  transcription_saved: '保存先: '
   trancription_time: '所要時間：%{duration}分'
+  queue_complete: '=== キュー処理が完了 ==='
+  total_jobs: '総ジョブ: %{total}'
+  completed: '完了: %{finished}'
+  failed: '失敗: %{errors}'
 
   # エラーメッセージ
   err_setup: 'セットアップ中にエラーが発生しました。インターネット接続が正常か確認し、プログラムを再起動してください。'
-  err_invalid_time_string: '無効な時間です：" %{time}"'
+  err_invalid_time_string: '無効な時間です: "%{time}"'
   err_options: 'オプションのエラー'
   err_no_audio_file: 'エラー：音声ファイルを選択してください。'
   err_no_transcript_file: 'エラー：転写が完了したファイル名を選択してください。'
   err_ffmpeg: 'ffmpegでエラーが発生しました'
-  err_converting_audio: 'ステップ1でエラーが発生しました-音声の変換。'
-  err_identifying_speakers: 'ステップ2でエラーが発生しました-話者の識別。'
+  err_converting_audio: 'ステップ1でエラーが発生しました - 音声の変換。'
+  err_identifying_speakers: 'ステップ2でエラーが発生しました - 話者の識別。'
   transcription_canceled: '本当に転写をキャンセルしますか？'   
   err_user_cancelation: 'ユーザーによってプロセスがキャンセルされました。'
   err_whisper_main: 'Whisperメインがエラーコード %{e} で終了しました'
-  err_transcription: 'ステップ3でエラーが発生しました-転写'
+  err_transcription: 'ステップ3でエラーが発生しました - 転写。'
   rescue_saving: '元のファイル名への保存に失敗しました。代わりにこのファイルに保存されました：%{file}'
   rescue_saving_failed: 'エラー：元のファイル名への保存に失敗しました。代替のファイル名も存在します。終了する必要があります。（Wordでトランスクリプトが既に開かれていないことを確認してください！）'
+  err_noScribeEdit_not_found: 'エラー: noScribe エディターが見つかりませんでした。'
+  err_vtt_invalid_options: '警告: 「重複発話」、「ポーズをマーク」と「タイムスタンプ」は VTT ファイルでサポートされていません。'
+  err_editor_invalid_format: 'エディターは html ファイルでのみ使用できます。それでも起動しますか？'
+  err_invalid_model: 'Whisper モデルの重複名を無視しました: "%{model_name}"'
 
   # ドキュメント内容
   doc_header: 'noScribe vers. %{version}で転写されました'
   doc_header_audio: '音声ファイル：%{file}'
-  pause_minutes: '(%{minutes}分[秒]休止)'
-  pause_seconds: '(%{seconds}秒休止)'
+  pause_minutes: '(%{minutes}分の休止)'
+  pause_seconds: '(%{seconds}秒の休止)'

--- a/trans/noScribe.pt.yml
+++ b/trans/noScribe.pt.yml
@@ -19,6 +19,8 @@ pt:
     Aproveite!
 
   setup_message: 'Primeira execução: Complete a configuração...'
+  new_release: 'Uma nova versão do noScribe está disponível (%{v}):'
+  new_release_download: 'Download: '
 
   # Elementos da interface
   label_audio_file: 'Arquivo de áudio:'
@@ -31,29 +33,40 @@ pt:
   label_stop: 'Parar (hh:mm:ss): ' 
 
   label_language: 'Idioma:'
-  label_speaker: 'Detecção de alto-falante:'
+  label_speaker: 'Detecção de locutor:'
   label_whisper_model: 'Modelo:'
-  label_add_custom_models: 'Adicionar modelo de IA...'  
+  label_add_custom_models: 'Adicionar modelo de IA...'
   label_overlapping: 'Sobreposição:'
   label_pause: 'Marcar pausas:'
   label_timestamps: 'Registos temporais:'
+  label_disfluencies: 'Disfluências:'
   
-  start_button: Iniciar 
+  start_button: Iniciar
   stop_button: Cancelar
+  editor_button: Editor
 
+  overall_progress: 'Progresso geral: '
   # Mensagens de log
   log_transcript_filename: 'Nome do arquivo de transcrição: '
   log_audio_file_selected: 'Arquivo de áudio selecionado: '
+  queue_start: '=== Iniciando fila ==='
+  queue_start_jobs: 'Processando %{total} tarefa(s) de transcrição'
+  start_job: 'Iniciando tarefa: %{audio_file}'
   start_audio_conversion: 'Convertendo áudio...'
   audio_conversion_finished: 'Conversão de áudio concluída'
-  start_identifiying_speakers: 'Identificação de alto-falantes...'
+  start_identifiying_speakers: 'Identificação de locutores...'
   loading_pyannote: 'Carregando pyannote'
   start_canceling: 'Cancelando... (aguarde um segundo)'
   start_transcription: 'Transcrição...'
-  loading_whisper: 'Carregando whisper'
-  transcription_finished: 'Transcrição concluída.' 
-  transcription_saved: 'Salvo em '
+  loading_whisper: 'Carregando Whisper'
+  vad: 'Detecção de atividade de voz...'
+  transcription_finished: 'Transcrição concluída.'
+  transcription_saved: 'Salvo em: '
   trancription_time: 'Duração: %{duration} minutos'
+  queue_complete: '=== Processamento da fila concluído ==='
+  total_jobs: 'Total de tarefas: %{total}'
+  completed: 'Concluídas: %{finished}'
+  failed: 'Falhas: %{errors}'
 
   # Mensagens de erro
   err_setup: 'Ocorreu um erro durante a configuração. Verifique se você possui uma conexão de internet funcionando e reinicie o programa.'
@@ -70,6 +83,10 @@ pt:
   err_transcription: 'Erro na etapa 3 - transcrição'
   rescue_saving: 'Falha ao salvar com o nome de arquivo original. Salvo em vez disso neste arquivo: %{file}'
   rescue_saving_failed: 'Erro: Falha ao salvar com o nome de arquivo original. O nome alternativo também existe. Preciso sair. (Certifique-se de que sua transcrição não esteja aberta no Word!)'
+  err_noScribeEdit_not_found: 'Erro: não foi possível encontrar o editor do noScribe.'
+  err_vtt_invalid_options: 'Aviso: as opções "Sobreposição", "Marcar pausas" e "Registos temporais" não são suportadas em arquivos VTT.'
+  err_editor_invalid_format: 'O editor só pode ser usado com arquivos HTML. Deseja iniciá-lo mesmo assim?'
+  err_invalid_model: 'Nome duplicado ignorado para o modelo whisper: "%{model_name}"'
 
   # Conteúdo do documento
   doc_header: 'Transcrito com noScribe versão %{version}'

--- a/trans/noScribe.ru.yml
+++ b/trans/noScribe.ru.yml
@@ -19,6 +19,8 @@ ru:
     Приятной работы!
 
   setup_message: 'Первый запуск: Завершите настройку...'
+  new_release: 'Доступна новая версия noScribe (%{v}):'
+  new_release_download: 'Загрузить: '
 
   # Элементы пользовательского интерфейса
   label_audio_file: 'Аудиофайл:'
@@ -37,23 +39,34 @@ ru:
   label_overlapping: 'Перекрытие речи:'
   label_pause: 'Отметьте паузы:'
   label_timestamps: 'Временные метки:'
+  label_disfluencies: 'Паразитные слова:'
   
-  start_button: Старт 
+  start_button: Старт
   stop_button: Отмена
+  editor_button: Редактор
 
+  overall_progress: 'Общий прогресс: '
   # Сообщения журнала
   log_transcript_filename: 'Имя файла транскрипции: '
   log_audio_file_selected: 'Выбран аудиофайл: '
+  queue_start: '=== Запуск очереди ==='
+  queue_start_jobs: 'Обработка %{total} задания(ий) на транскрипцию'
+  start_job: 'Запуск задания: %{audio_file}'
   start_audio_conversion: 'Преобразование аудио...'
   audio_conversion_finished: 'Преобразование аудио завершено'
   start_identifiying_speakers: 'Определение дикторов...'
   loading_pyannote: 'Загрузка pyannote'
   start_canceling: 'Отмена... (пожалуйста, подождите)'
   start_transcription: 'Транскрибация...'
-  loading_whisper: 'Загрузка whisper'
-  transcription_finished: 'Транскрибация завершена.' 
-  transcription_saved: 'Сохранено в '
+  loading_whisper: 'Загрузка Whisper'
+  vad: 'Обнаружение голосовой активности...'
+  transcription_finished: 'Транскрибация завершена.'
+  transcription_saved: 'Сохранено в: '
   trancription_time: 'Продолжительность: %{duration} минут'
+  queue_complete: '=== Обработка очереди завершена ==='
+  total_jobs: 'Всего заданий: %{total}'
+  completed: 'Завершено: %{finished}'
+  failed: 'Неудачных: %{errors}'
 
   # Сообщения об ошибках
   err_setup: 'Произошла ошибка при настройке. Проверьте подключение к интернету и перезапустите программу.'
@@ -70,6 +83,10 @@ ru:
   err_transcription: 'Ошибка на шаге 3 - транскрипция'
   rescue_saving: 'Не удалось сохранить в оригинальный файл. Сохранено в файл: %{file}'
   rescue_saving_failed: 'Ошибка: Не удалось сохранить в оригинальный файл. Файл с альтернативным именем также существует. Приложение будет закрыто. (Убедитесь, что ваша транскрипция не открыта в Word!)'
+  err_noScribeEdit_not_found: 'Ошибка: не удалось найти редактор noScribe.'
+  err_vtt_invalid_options: 'Предупреждение: параметры "Перекрытие речи", "Отметьте паузы" и "Временные метки" не поддерживаются в файлах VTT.'
+  err_editor_invalid_format: 'Редактор может использоваться только с HTML-файлами. Запустить его все равно?'
+  err_invalid_model: 'Игнорируется повторяющееся имя модели whisper: "%{model_name}"'
 
   # Содержимое документа
   doc_header: 'Транскрибировано с помощью noScribe версии %{version}'

--- a/trans/noScribe.zh-CN.yml
+++ b/trans/noScribe.zh-CN.yml
@@ -38,7 +38,7 @@ zh-CN: &defaults
   label_overlapping: '重叠发言：'
   label_pause: '标记停顿：'
   label_timestamps: '时间戳：'
-  label_disfluencies: '语言停顿：'
+  label_disfluencies: '填充词：'
   
   start_button: 开始 
   stop_button: 取消
@@ -49,20 +49,25 @@ zh-CN: &defaults
   # 日志信息
   log_transcript_filename: '转录文件名：'
   log_audio_file_selected: '已选择音频文件：'
+  queue_start: '=== 开始队列 ==='
+  queue_start_jobs: '正在处理 %{total} 个转录任务'
+  start_job: '开始任务：%{audio_file}'
   start_audio_conversion: '正在转换音频...'
   audio_conversion_finished: '音频转换完成'
   start_identifiying_speakers: '正在识别说话人...'
-  loading_pyannote: '加载pyannote中'
+  loading_pyannote: '正在加载 pyannote'
   start_canceling: '正在取消...（请稍候）'
   start_transcription: '正在转录...'
-  loading_whisper: '加载whisper中'
-  start_transcription: '转录...'
-  loading_whisper: '正在加载whisper'
+  loading_whisper: '正在加载 Whisper'
   vad: '语音活动检测...'
-  
-  transcription_finished: '转录完成。' 
-  transcription_saved: '已保存至'
+
+  transcription_finished: '转录完成。'
+  transcription_saved: '已保存至：'
   trancription_time: '时长：%{duration}分钟'
+  queue_complete: '=== 队列处理完成 ==='
+  total_jobs: '任务总数：%{total}'
+  completed: '已完成：%{finished}'
+  failed: '失败：%{errors}'
 
   # 错误信息
   err_setup: '设置过程中发生错误。请检查您的网络连接并重新启动程序。'
@@ -82,6 +87,7 @@ zh-CN: &defaults
   err_noScribeEdit_not_found: '错误：找不到noScribe编辑器。'
   err_vtt_invalid_options: '警告：VTT文件不支持“重叠发言”、“标记停顿”和“时间戳”选项。'
   err_editor_invalid_format: '编辑器只能用于html文件。你仍然要启动它吗？'
+  err_invalid_model: '忽略了重复的 whisper 模型名称："%{model_name}"'
 
   # 文档内容
   doc_header: '使用noScribe %{version} 版本转录'


### PR DESCRIPTION
## Summary
- refine non-English translations with localized timestamp labels and speaker detection text
- standardize Whisper loading messages and save-path log prefixes
- fix grammatical issues and YAML structure across translations

## Testing
- `python - <<'PY'
import yaml,glob,sys
import io
for f in glob.glob('trans/noScribe.*.yml'):
    with open(f,'r',encoding='utf-8') as fh:
        yaml.safe_load(fh)
print('ok')
PY` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_b_689e4268127c83228ae440c40a8be5e6