### PR TITLE
Add missing UI and job status translations across locales

### DIFF
--- a/trans/noScribe.de.yml
+++ b/trans/noScribe.de.yml
@@ -21,8 +21,10 @@ de:
   setup_message: 'Einrichtung abschließen...'
   new_release: 'Eine neue Version von noScribe ist verfügbar (%{v}):'
   new_release_download: 'Download: '
-  
+
   # UI Elements
+  tab_log: Protokoll
+  tab_queue: Warteschlange
   label_audio_file: 'Audiodatei:'
   label_audio_file_name: <Audiodatei wählen>
   
@@ -46,6 +48,20 @@ de:
   editor_button: Editor
 
   overall_progress: 'Fortschritt insgesamt: '
+
+  # job status
+  waiting: 'wartend'
+  audio_conversion: 'Audiokonvertierung'
+  speaker_identification: 'Sprecher:innenidentifikation'
+  transcription: 'Transkription'
+  finished: 'abgeschlossen'
+  error: 'Fehler'
+
+  # job queue tooltips
+  job_tt_waiting: 'Auftrag wartet...'
+  job_tt_running: 'Auftrag läuft. Details im Protokoll-Tab.'
+  job_tt_finished: 'Erfolgreich. Klicken, um im noScribe-Editor zu öffnen.'
+  job_tt_error: 'Fehler bei der Auftragsverarbeitung: %{error_msg}'
 
   # log messages
   log_transcript_filename: 'Transkript-Dateiname: '

--- a/trans/noScribe.es.yml
+++ b/trans/noScribe.es.yml
@@ -22,6 +22,8 @@ es:
   new_release_download: 'Descargar: '
 
   # Elementos de la interfaz de usuario
+  tab_log: Registro
+  tab_queue: Cola
   label_audio_file: 'Archivo de audio:'
   label_audio_file_name: <seleccionar archivo>
   
@@ -45,6 +47,21 @@ es:
   editor_button: Editor
 
   overall_progress: 'Progreso total: '
+
+  # Estado de la tarea
+  waiting: 'esperando'
+  audio_conversion: 'conversión de audio'
+  speaker_identification: 'identificación de hablantes'
+  transcription: 'transcripción'
+  finished: 'finalizado'
+  error: 'error'
+
+  # Información sobre la cola de trabajos
+  job_tt_waiting: 'Tarea en espera...'
+  job_tt_running: 'La tarea se está ejecutando. Vea la pestaña de registro para detalles.'
+  job_tt_finished: 'Éxito. Haz clic para abrir la salida en el editor de noScribe.'
+  job_tt_error: 'Se produjo un error durante el procesamiento: %{error_msg}'
+
   # Mensajes de registro
   log_transcript_filename: 'Nombre de archivo de transcripción: '
   log_audio_file_selected: 'Archivo de audio seleccionado: '

--- a/trans/noScribe.fr.yml
+++ b/trans/noScribe.fr.yml
@@ -22,6 +22,8 @@ fr:
   new_release_download: "Télécharger : "
 
   # Éléments de l'interface utilisateur
+  tab_log: Journal
+  tab_queue: File d'attente
   label_audio_file: "Fichier audio :"
   label_audio_file_name: <sélectionner un fichier>
   
@@ -45,6 +47,21 @@ fr:
   editor_button: "Éditeur"
 
   overall_progress: 'Progression totale : '
+
+  # Statut de la tâche
+  waiting: 'en attente'
+  audio_conversion: 'conversion audio'
+  speaker_identification: 'identification des locuteurs'
+  transcription: 'transcription'
+  finished: 'terminé'
+  error: 'erreur'
+
+  # Info-bulles de la file d'attente
+  job_tt_waiting: 'Tâche en attente...'
+  job_tt_running: "La tâche est en cours. Voir l'onglet journal pour les détails."
+  job_tt_finished: "Succès. Cliquez pour ouvrir le résultat dans l'éditeur noScribe."
+  job_tt_error: "Une erreur est survenue lors du traitement de la tâche : %{error_msg}"
+
   # Messages de journalisation
   log_transcript_filename: "Nom du fichier de transcription : "
   log_audio_file_selected: "Fichier audio sélectionné : "

--- a/trans/noScribe.it.yml
+++ b/trans/noScribe.it.yml
@@ -22,6 +22,8 @@ it:
   new_release_download: 'Scarica: '
 
   # Elementi dell'interfaccia utente
+  tab_log: Registro
+  tab_queue: Coda
   label_audio_file: 'File audio:'
   label_audio_file_name: <seleziona file>
   
@@ -43,8 +45,23 @@ it:
   start_button: Avvia
   stop_button: Annulla
   editor_button: Editor
-
+  
   overall_progress: 'Progresso totale: '
+
+  # Stato del lavoro
+  waiting: 'in attesa'
+  audio_conversion: 'conversione audio'
+  speaker_identification: 'identificazione parlanti'
+  transcription: 'trascrizione'
+  finished: 'completato'
+  error: 'errore'
+
+  # Suggerimenti della coda di lavori
+  job_tt_waiting: 'Processo in attesa...'
+  job_tt_running: 'Processo in esecuzione. Vedi la scheda registro per i dettagli.'
+  job_tt_finished: 'Completato. Clicca per aprire l\'output nell\'editor noScribe.'
+  job_tt_error: 'Si è verificato un errore durante l\'elaborazione: %{error_msg}'
+
   # Messaggi di log
   log_transcript_filename: 'Nome file trascrizione: '
   log_audio_file_selected: 'File audio selezionato: '

--- a/trans/noScribe.ja.yml
+++ b/trans/noScribe.ja.yml
@@ -23,6 +23,8 @@ ja:
   new_release_download: 'ダウンロード: '
 
   # UI要素
+  tab_log: ログ
+  tab_queue: キュー
   label_audio_file: '音声ファイル：'
   label_audio_file_name: <ファイルを選択>
   
@@ -45,6 +47,20 @@ ja:
   stop_button: キャンセル
   editor_button: エディター
   overall_progress: '全体の進行状況：'
+
+  # ジョブの状態
+  waiting: '待機中'
+  audio_conversion: 'オーディオ変換'
+  speaker_identification: '話者識別'
+  transcription: '転写'
+  finished: '完了'
+  error: 'エラー'
+
+  # ジョブキューのツールチップ
+  job_tt_waiting: 'ジョブ待機中...'
+  job_tt_running: 'ジョブ実行中。詳細はログタブを参照してください。'
+  job_tt_finished: '成功。クリックして noScribe エディターで出力を開きます。'
+  job_tt_error: 'ジョブ処理中にエラーが発生しました: %{error_msg}'
 
   # ログメッセージ
   log_transcript_filename: '転写ファイル名：'

--- a/trans/noScribe.pt.yml
+++ b/trans/noScribe.pt.yml
@@ -23,6 +23,8 @@ pt:
   new_release_download: 'Download: '
 
   # Elementos da interface
+  tab_log: Registro
+  tab_queue: Fila
   label_audio_file: 'Arquivo de áudio:'
   label_audio_file_name: <selecionar arquivo>
   
@@ -46,6 +48,21 @@ pt:
   editor_button: Editor
 
   overall_progress: 'Progresso geral: '
+
+  # Status do trabalho
+  waiting: 'aguardando'
+  audio_conversion: 'conversão de áudio'
+  speaker_identification: 'identificação de locutores'
+  transcription: 'transcrição'
+  finished: 'concluído'
+  error: 'erro'
+
+  # Dicas da fila de trabalhos
+  job_tt_waiting: 'Tarefa aguardando...'
+  job_tt_running: 'Tarefa em execução. Veja a aba de registro para detalhes.'
+  job_tt_finished: 'Sucesso. Clique para abrir o resultado no editor noScribe.'
+  job_tt_error: 'Ocorreu um erro durante o processamento: %{error_msg}'
+
   # Mensagens de log
   log_transcript_filename: 'Nome do arquivo de transcrição: '
   log_audio_file_selected: 'Arquivo de áudio selecionado: '

--- a/trans/noScribe.ru.yml
+++ b/trans/noScribe.ru.yml
@@ -23,6 +23,8 @@ ru:
   new_release_download: 'Загрузить: '
 
   # Элементы пользовательского интерфейса
+  tab_log: Журнал
+  tab_queue: Очередь
   label_audio_file: 'Аудиофайл:'
   label_audio_file_name: <выберите файл>
   
@@ -44,8 +46,23 @@ ru:
   start_button: Старт
   stop_button: Отмена
   editor_button: Редактор
-
+ 
   overall_progress: 'Общий прогресс: '
+
+  # Статус задания
+  waiting: 'ожидание'
+  audio_conversion: 'преобразование аудио'
+  speaker_identification: 'определение дикторов'
+  transcription: 'транскрибация'
+  finished: 'завершено'
+  error: 'ошибка'
+
+  # Подсказки очереди заданий
+  job_tt_waiting: 'Задача ожидает...'
+  job_tt_running: 'Задача выполняется. Подробности смотрите во вкладке журнала.'
+  job_tt_finished: 'Успешно. Нажмите, чтобы открыть результат в редакторе noScribe.'
+  job_tt_error: 'Во время обработки задачи произошла ошибка: %{error_msg}'
+
   # Сообщения журнала
   log_transcript_filename: 'Имя файла транскрипции: '
   log_audio_file_selected: 'Выбран аудиофайл: '

--- a/trans/noScribe.zh-CN.yml
+++ b/trans/noScribe.zh-CN.yml
@@ -22,6 +22,8 @@ zh-CN: &defaults
   new_release_download: '下载：'
 
   # 用户界面元素
+  tab_log: 日志
+  tab_queue: 队列
   label_audio_file: '音频文件：'
   label_audio_file_name: <选择文件>
   
@@ -45,6 +47,20 @@ zh-CN: &defaults
   editor_button: 编辑器
 
   overall_progress: '总进度：'
+
+  # 任务状态
+  waiting: '等待中'
+  audio_conversion: '音频转换'
+  speaker_identification: '说话人识别'
+  transcription: '转录'
+  finished: '完成'
+  error: '错误'
+
+  # 队列提示
+  job_tt_waiting: '任务等待中...'
+  job_tt_running: '任务运行中。详情请查看日志标签。'
+  job_tt_finished: '成功。点击在 noScribe 编辑器中打开输出。'
+  job_tt_error: '处理任务时发生错误：%{error_msg}'
 
   # 日志信息
   log_transcript_filename: '转录文件名：'


### PR DESCRIPTION
## Summary
- fill in `tab_log` and `tab_queue` entries across locale files
- add job status and queue tooltip strings for all translations

No tests were run per repository instructions.

------
https://chatgpt.com/codex/tasks/task_b_68a5d6e719a083228713034c6f54dde3