### PR TITLE
refactor: drop unused imports, import os before using it

### DIFF
--- a/noScribe.py
+++ b/noScribe.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import sys
+import os
 # In the compiled version (no command line), stdout is None which might lead to errors
 if sys.stdout is None:
     sys.stdout = open(os.devnull, "w")
@@ -28,12 +29,11 @@ from tkHyperlinkManager import HyperlinkManager
 import webbrowser
 from functools import partial
 from PIL import Image
-import os
 import platform
 import yaml
 import locale
 import appdirs
-from subprocess import run, call, Popen, PIPE, STDOUT
+from subprocess import run, Popen, PIPE, STDOUT
 if platform.system() == 'Windows':
     # import torch.cuda # to check with torch.cuda.is_available()
     from subprocess import STARTUPINFO, STARTF_USESHOWWINDOW
@@ -51,7 +51,6 @@ from faster_whisper.vad import VadOptions, get_speech_timestamps
 import AdvancedHTMLParser
 import html
 from threading import Thread
-import time
 from tempfile import TemporaryDirectory
 import datetime
 from pathlib import Path


### PR DESCRIPTION
Only a small PR that drops unused imports and move `os` to the top as it has been used before being imported.