### PR TITLE
Fix PyTorch 2.6+ compatibility for pyannote speaker detection

### DIFF
--- a/environments/requirements_linux.txt
+++ b/environments/requirements_linux.txt
@@ -6,6 +6,7 @@ appdirs
 customtkinter
 CTkToolTip
 faster-whisper
+omegaconf
 Pillow
 pyannote.audio>=4
 pyinstaller

--- a/environments/requirements_macOS_arm64.txt
+++ b/environments/requirements_macOS_arm64.txt
@@ -6,6 +6,7 @@ appdirs
 customtkinter
 CTkToolTip
 faster-whisper
+omegaconf
 Pillow
 pyannote.audio>=4
 pyinstaller

--- a/environments/requirements_win_cpu.txt
+++ b/environments/requirements_win_cpu.txt
@@ -6,6 +6,7 @@ cpufeature
 customtkinter
 CTkToolTip
 faster-whisper
+omegaconf
 Pillow
 pyannote.audio>=4.0
 pyinstaller=6.14.1 

--- a/environments/requirements_win_cuda.txt
+++ b/environments/requirements_win_cuda.txt
@@ -9,6 +9,7 @@ cpufeature
 customtkinter
 CTkToolTip
 faster-whisper
+omegaconf
 Pillow
 pyannote.audio>=4.0
 pyinstaller==6.14.1 

--- a/pyannote_mp_worker.py
+++ b/pyannote_mp_worker.py
@@ -25,7 +25,14 @@ def pyannote_proc_entrypoint(args: dict, q):
         import yaml
         import torch
         if platform.system() == "Darwin" and platform.machine() == "x86_64":
-           torch.set_num_threads(1)        
+           torch.set_num_threads(1)
+
+        # PyTorch 2.6+ changed weights_only default to True.
+        # Add safe globals for pyannote model checkpoint loading.
+        from pyannote.audio.core.task import Specifications, Problem, Resolution
+        from omegaconf import ListConfig, DictConfig
+        torch.serialization.add_safe_globals([Specifications, Problem, Resolution, ListConfig, DictConfig])
+
         from pyannote.audio import Pipeline
         from tempfile import TemporaryDirectory
 


### PR DESCRIPTION
## Summary
- Fix speaker detection breaking with PyTorch 2.6+ due to `weights_only=True` default change
- Add required safe globals for pyannote model checkpoint loading
- Add `omegaconf` to requirements files

## Problem
PyTorch 2.6 changed the default value of `weights_only` in `torch.load()` from `False` to `True`. This breaks loading pyannote model checkpoints that contain pickled objects like `Specifications`, `Problem`, and `Resolution` classes.

Error message:
```
_pickle.UnpicklingError: Weights only load failed...
WeightsUnpickler error: Unsupported global: GLOBAL pyannote.audio.core.task.Specifications was not an allowed global by default.
```

## Solution
Add the required classes to `torch.serialization.safe_globals` before loading the pyannote pipeline in `pyannote_mp_worker.py`:

```python
from pyannote.audio.core.task import Specifications, Problem, Resolution
from omegaconf import ListConfig, DictConfig
torch.serialization.add_safe_globals([Specifications, Problem, Resolution, ListConfig, DictConfig])
```

## Test plan
- [x] Tested speaker detection with pyannote.audio 4.0.2 and PyTorch 2.8.0 on macOS
- [x] Verified speaker labels (S00, S01, etc.) appear in transcripts
- [x] Confirmed all pyannote pipeline stages complete (segmentation, speaker_counting, embeddings, discrete_diarization)

## Related issues
- https://github.com/pyannote/pyannote-audio/issues/1908

🤖 Generated with [Claude Code](https://claude.com/claude-code)