### PR TITLE
fix: fix escaping of apostrophes again

### DIFF
--- a/tests/test_apostrophe_fix.py
+++ b/tests/test_apostrophe_fix.py
@@ -3,16 +3,14 @@ Test for the apostrophe/quote escaping fix.
 
 Verifies that html.escape(quote=False) prevents &#x27; from appearing
 in HTML, VTT, and TXT output.
-"""
-import html
-import sys
-import os
 
-# Add parent dir to path so we can import from noScribe.py
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+TODO: change these test functions to use the actual functions from noscribe
+after refactoring the code.
+"""
+
+import html
 
 import AdvancedHTMLParser
-import utils
 
 
 def _build_doc_with_text(text: str) -> AdvancedHTMLParser.AdvancedHTMLParser:
@@ -32,28 +30,6 @@ def _build_doc_with_text(text: str) -> AdvancedHTMLParser.AdvancedHTMLParser:
     return d
 
 
-def _html_node_to_text(node) -> str:
-    """Mirrors the html_node_to_text function from noScribe.py (line 349)."""
-    if AdvancedHTMLParser.isTextNode(node):
-        return html.unescape(node)
-    elif AdvancedHTMLParser.isTagNode(node):
-        text_parts = []
-        for child in node.childBlocks:
-            text = _html_node_to_text(child)
-            if text:
-                text_parts.append(text)
-        return ''.join(text_parts)
-    return ''
-
-
-def _vtt_escape(txt: str) -> str:
-    """Mirrors vtt_escape from noScribe.py (line 379) after the fix."""
-    txt = html.escape(txt, quote=False)
-    while txt.find('\n\n') > -1:
-        txt = txt.replace('\n\n', '\n')
-    return txt
-
-
 class TestApostropheFix:
     """Tests that apostrophes are correctly preserved in all output formats."""
 
@@ -63,20 +39,6 @@ class TestApostropheFix:
         html_out = d.asHTML()
         assert "Romy's" in html_out, f"Expected literal apostrophe in HTML output, got: {html_out}"
         assert "&#x27;" not in html_out, f"Found &#x27; entity in HTML output: {html_out}"
-
-    def test_txt_output_no_entity(self):
-        """TXT output should contain literal apostrophe."""
-        d = _build_doc_with_text("Romy's story")
-        txt_out = _html_node_to_text(d.body)
-        assert "Romy's" in txt_out, f"Expected literal apostrophe in TXT output, got: {txt_out}"
-        assert "&#x27;" not in txt_out, f"Found &#x27; entity in TXT output: {txt_out}"
-
-    def test_vtt_escape_no_entity(self):
-        """vtt_escape should not escape apostrophes."""
-        result = _vtt_escape("Romy's story")
-        assert "Romy's" in result, f"Expected literal apostrophe in VTT output, got: {result}"
-        assert "&#x27;" not in result, f"Found &#x27; entity in VTT output: {result}"
-
     def test_html_still_escapes_dangerous_chars(self):
         """Ensure that <, >, & are still properly escaped."""
         d = _build_doc_with_text("a < b & c > d")
@@ -84,13 +46,6 @@ class TestApostropheFix:
         assert "&lt;" in html_out, "< should be escaped to &lt;"
         assert "&amp;" in html_out, "& should be escaped to &amp;"
         assert "&gt;" in html_out, "> should be escaped to &gt;"
-
-    def test_vtt_still_escapes_dangerous_chars(self):
-        """Ensure that <, >, & are still properly escaped in VTT."""
-        result = _vtt_escape("a < b & c > d")
-        assert "&lt;" in result, "< should be escaped to &lt;"
-        assert "&amp;" in result, "& should be escaped to &amp;"
-        assert "&gt;" in result, "> should be escaped to &gt;"
 
     def test_double_quotes_not_escaped(self):
         """Double quotes should also not be escaped in text content."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,9 +2,11 @@
 Tests for the `utils.py` file / module.
 """
 
-from pathlib import Path
+import html
 import importlib.resources as impres
+from pathlib import Path
 
+import AdvancedHTMLParser
 import pytest
 import utils
 
@@ -282,7 +284,7 @@ def test_html_to_webvtt():
         <p></p>
         <p><a name="ts_0_12140_s1"></a></p>
         <p><a name="ts_0_12140_s1"> </a></p>
-        <p><a name="ts_0_12140_s1">I said something.</a></p>
+        <p><a name="ts_0_12140_s1">I said something about Romy's story.</a></p>
     </body>
     """
     result_string = (
@@ -291,7 +293,7 @@ def test_html_to_webvtt():
         "My Information Header\n\n"
         "1\n"
         "00:00:00.000 --> 00:00:12.140\n"
-        "<v s1>I said something.\n\n"
+        "<v s1>I said something about Romy's story.\n\n"
     )
     assert utils.html_to_webvtt(html_string) == result_string
 
@@ -303,3 +305,63 @@ def test_html_to_webvtt():
     result_string = result_file.read_text(encoding="utf-8")
 
     assert utils.html_to_webvtt(html_string) == result_string
+
+
+class TestApostropheFix:
+    """
+    Tests that apostrophes are correctly preserved in all output formats.
+
+    See https://github.com/kaixxx/noScribe/issues/272 and
+    https://github.com/kaixxx/noScribe/pull/273 for a discussion. However,
+    other entities should still be transformed.
+
+    TODO: Do this for all different output formats. After refactoring the
+    remaining code, check the HTML output format here as well.
+    """
+
+    def _build_doc_with_text(self, text: str) -> AdvancedHTMLParser.AdvancedHTMLParser:
+        """
+        Simulate how noScribe builds the HTML DOM with transcript text. TODO:
+        replace this with the actual code from noscribe after refactoring.
+        """
+
+        d = AdvancedHTMLParser.AdvancedHTMLParser()
+        d.parseStr("<html><body></body></html>")
+
+        p = d.createElement("p")
+        d.body.appendChild(p)
+
+        # This mirrors line 2859 + 2922-2923 of noScribe.py (after the fix)
+        seg_html = html.escape(text, quote=False)
+        a_html = f'<a name="ts_0_1000_S01" >{seg_html}</a>'
+        a = d.createElementFromHTML(a_html)
+        p.appendChild(a)
+
+        return d
+
+    def test_not_escaping_apostrophes_webvtt(self):
+        result = utils._vtt_escape("Romy's story")
+
+        assert "Romy's" in result, (
+            f"Expected literal apostrophe in VTT output, got: {result}"
+        )
+        assert "&#x27;" not in result, f"Found &#x27; entity in VTT output: {result}"
+
+        # Ensure that <, >, & are still properly escaped in VTT.
+        result = utils._vtt_escape("a < b & c > d")
+        assert "&lt;" in result, "< should be escaped to &lt;"
+        assert "&amp;" in result, "& should be escaped to &amp;"
+        assert "&gt;" in result, "> should be escaped to &gt;"
+
+    def test_not_escaping_apostrophes_txt(self):
+        d = self._build_doc_with_text("Romy's story")
+        txt_out = utils.html_to_text(d.asHTML(), use_only_body=True)
+        assert "Romy's" in txt_out, (
+            f"Expected literal apostrophe in TXT output, got: {txt_out}"
+        )
+        assert "&#x27;" not in txt_out, f"Found &#x27; entity in TXT output: {txt_out}"
+
+        # Ensure that <, >, & are still the same in plain text.
+        d = self._build_doc_with_text("a < b & c > d")
+        txt_out = utils.html_to_text(d.asHTML(), use_only_body=True)
+        assert txt_out == "a < b & c > d"

--- a/utils.py
+++ b/utils.py
@@ -194,9 +194,8 @@ def html_to_text(html_str: str, use_only_body=False) -> str:
                     self.body_found = True
 
         def handle_endtag(self, tag):
-            if self.body_found:
-                if tag in HTML_BLOCK_LEVEL_ELEMENTS:
-                    self.result.append("\n")
+            if self.body_found and tag in HTML_BLOCK_LEVEL_ELEMENTS:
+                self.result.append("\n")
 
         def handle_data(self, data):
             if self.body_found:
@@ -236,7 +235,7 @@ def _vtt_escape(txt: str) -> str:
         The processed string with escaped HTML characters and normalized newlines.
     """
 
-    txt = html.escape(txt)
+    txt = html.escape(txt, quote=False)
 
     # Make sure to replace all double newlines with a single newline. Use a
     # while loop to find repetitive occurences.


### PR DESCRIPTION
I think this slipped in as not the real functions were used in the tests.