### PR TITLE
Word-Level Timestamp Feature - Highly experimental

### DIFF
--- a/noScribe.py
+++ b/noScribe.py
@@ -381,6 +381,7 @@ class TranscriptionJob:
         self.speaker_detection: str = 'auto'
         self.overlapping: bool = True
         self.timestamps: bool = False
+        self.word_timestamps: bool = False
         self.disfluencies: bool = True
         self.pause: int = 0  # index value (0=none, 1=1sec+, etc.)
         
@@ -601,7 +602,7 @@ class TranscriptionQueue:
 
 def create_transcription_job(audio_file=None, transcript_file=None, start_time=None, stop_time=None,
                            language_name=None, whisper_model_name=None, speaker_detection=None,
-                           overlapping=None, timestamps=None, disfluencies=None, pause=None,
+                           overlapping=None, timestamps=None, word_timestamps=None, disfluencies=None, pause=None,
                            cli_mode=False) -> TranscriptionJob:
     """Create a TranscriptionJob with all default values
     
@@ -642,6 +643,7 @@ def create_transcription_job(audio_file=None, transcript_file=None, start_time=N
     job.speaker_detection = speaker_detection if speaker_detection is not None else 'auto'
     job.overlapping = overlapping if overlapping is not None else True
     job.timestamps = timestamps if timestamps is not None else False
+    job.word_timestamps = word_timestamps if word_timestamps is not None else False
     job.disfluencies = disfluencies if disfluencies is not None else True
     
     # Pause setting
@@ -1198,7 +1200,18 @@ class App(ctk.CTk):
             self.check_box_timestamps.select()
         else:
             self.check_box_timestamps.deselect()
-        
+
+        # Word-level timestamps
+        self.label_word_timestamps = ctk.CTkLabel(self.frame_options, text=t('label_word_timestamps'))
+        self.label_word_timestamps.grid(column=0, row=9, sticky='w', pady=5)
+        self.check_box_word_timestamps = ctk.CTkCheckBox(self.frame_options, text='')
+        self.check_box_word_timestamps.grid(column=1, row=9, sticky='e', pady=5)
+        check_box_word_timestamps = config.get('last_word_timestamps', False)
+        if check_box_word_timestamps:
+            self.check_box_word_timestamps.select()
+        else:
+            self.check_box_word_timestamps.deselect()
+
         # Start control: single CTkOptionMenu styled like a button
         # Create a container so we can show/hide as one control
         self.start_button_container = ctk.CTkFrame(self.sidebar_frame, fg_color='transparent')
@@ -2221,6 +2234,7 @@ class App(ctk.CTk):
                 speaker_detection=self.option_menu_speaker.get(),
                 overlapping=self.check_box_overlapping.get(),
                 timestamps=self.check_box_timestamps.get(),
+                word_timestamps=self.check_box_word_timestamps.get(),
                 disfluencies=self.check_box_disfluencies.get(),
                 pause=self.option_menu_pause.get(),  # Pass string value
                 cli_mode=False
@@ -2760,8 +2774,12 @@ class App(ctk.CTk):
 
                         # write text to the doc
                         # diarization (speaker detection)?
+                        # Run speaker detection ONCE. Builds seg_html/seg_text (segment-level output)
+                        # and word_prefix_html (prefix for the first word anchor) in parallel so both
+                        # output modes use identical, proven detection logic.
                         seg_text = segment.text
                         seg_html = html.escape(seg_text, quote=False)
+                        word_prefix_html = ''
 
                         if job.speaker_detection != 'none':
                             new_speaker = find_speaker(diarization, start, end)
@@ -2770,11 +2788,15 @@ class App(ctk.CTk):
                                     prev_speaker = speaker
                                     speaker = new_speaker
                                     seg_text = f' {speaker}:{seg_text}'
-                                    seg_html = html.escape(seg_text, quote=False)                                
-                                elif (speaker[:2] == '//') and (new_speaker == prev_speaker): # was overlapping speech and we are returning to the previous speaker 
+                                    seg_html = html.escape(seg_text, quote=False)
+                                    word_prefix_html = html.escape(f' {speaker}:', quote=False)
+                                    self.log(f' {speaker}:')
+                                elif (speaker[:2] == '//') and (new_speaker == prev_speaker): # was overlapping speech and we are returning to the previous speaker
                                     speaker = new_speaker
                                     seg_text = f'//{seg_text}'
                                     seg_html = html.escape(seg_text, quote=False)
+                                    word_prefix_html = '//'
+                                    self.log('//')
                                 else: # new speaker, not overlapping
                                     if speaker[:2] == '//': # was overlapping speech, mark the end
                                         last_elem = p.lastElementChild
@@ -2791,30 +2813,40 @@ class App(ctk.CTk):
                                     speaker = new_speaker
                                     # add timestamp
                                     if job.timestamps:
-                                        seg_html = f'{speaker}: <span style="color: {job.timestamp_color}" >{ts}</span>{html.escape(seg_text, quote=False)}'
+                                        seg_html = f'{html.escape(speaker + ": ", quote=False)}<span style="color: {job.timestamp_color}" >{ts}</span>{html.escape(seg_text, quote=False)}'
                                         seg_text = f'{speaker}: {ts}{seg_text}'
+                                        word_prefix_html = f'{html.escape(speaker + ": ", quote=False)}<span style="color: {job.timestamp_color}" >{ts}</span>'
+                                        self.log(f'{speaker}: {ts}')
                                         last_timestamp_ms = start
                                     else:
                                         if job.file_ext != 'vtt': # in vtt files, speaker names are added as special voice tags so skip this here
                                             seg_text = f'{speaker}:{seg_text}'
                                             seg_html = html.escape(seg_text, quote=False)
+                                            word_prefix_html = html.escape(f'{speaker}:', quote=False)
+                                            self.log(f'{speaker}:')
                                         else:
                                             seg_html = html.escape(seg_text, quote=False).lstrip()
                                             seg_text = f'{speaker}:{seg_text}'
-                                        
+                                            word_prefix_html = html.escape(f'{speaker}:', quote=False)
+                                            self.log(f'{speaker}:')
+
                             else: # same speaker
                                 if job.timestamps:
                                     if (start - last_timestamp_ms) > job.timestamp_interval:
-                                        seg_html = f' <span style=\"color: {job.timestamp_color}\" >{ts}</span>{html.escape(seg_text, quote=False)}'
+                                        seg_html = f' <span style="color: {job.timestamp_color}" >{ts}</span>{html.escape(seg_text, quote=False)}'
                                         seg_text = f' {ts}{seg_text}'
+                                        word_prefix_html = f'<span style="color: {job.timestamp_color}" >{ts}</span>'
+                                        self.log(ts)
                                         last_timestamp_ms = start
                                     else:
                                         seg_html = html.escape(seg_text, quote=False)
 
                         else: # no speaker detection
                             if job.timestamps and (first_segment or (start - last_timestamp_ms) > job.timestamp_interval):
-                                seg_html = f' <span style=\"color: {job.timestamp_color}\" >{ts}</span>{html.escape(seg_text, quote=False)}'
+                                seg_html = f' <span style="color: {job.timestamp_color}" >{ts}</span>{html.escape(seg_text, quote=False)}'
                                 seg_text = f' {ts}{seg_text}'
+                                word_prefix_html = f'<span style="color: {job.timestamp_color}" >{ts}</span>'
+                                self.log(ts)
                                 last_timestamp_ms = start
                             else:
                                 seg_html = html.escape(seg_text, quote=False)
@@ -2823,13 +2855,32 @@ class App(ctk.CTk):
                                 seg_text = seg_text.lstrip()
                                 seg_html = seg_html.lstrip()
 
-                        # Create bookmark with audio timestamps start to end and add the current segment.
-                        a_html = f'<a name=\"ts_{orig_audio_start}_{orig_audio_end}_{speaker}\" >{seg_html}</a>'
-                        a = d.createElementFromHTML(a_html)
-                        p.appendChild(a)
+                        if job.word_timestamps and segment.words:
+                            # Emit one anchor per word; prefix is embedded in the first word's anchor
+                            # so every piece of text stays reachable via an anchor (required by noScribeEdit).
+                            first_word = True
+                            for w in segment.words:
+                                w_start_orig = job.start + round(w['start'] * 1000.0)
+                                w_end_orig   = job.start + round(w['end']   * 1000.0)
+                                w_html = html.escape(w['word'], quote=False)
+                                if first_word:
+                                    if first_segment:
+                                        w_html = w_html.lstrip()
+                                    w_html = word_prefix_html + w_html
+                                    first_word = False
+                                a_html = f'<a name="ts_{w_start_orig}_{w_end_orig}_{speaker}">{w_html}</a>'
+                                p.appendChild(d.createElementFromHTML(a_html))
 
-                        self.log(seg_text)
-                        
+                            self.log(seg_text)
+
+                        else:
+                            # Create bookmark with audio timestamps start to end and add the current segment.
+                            a_html = f'<a name="ts_{orig_audio_start}_{orig_audio_end}_{speaker}" >{seg_html}</a>'
+                            a = d.createElementFromHTML(a_html)
+                            p.appendChild(a)
+
+                            self.log(seg_text)
+
                         first_segment = False
 
                         # auto save periodically
@@ -3264,6 +3315,7 @@ class App(ctk.CTk):
             config['last_pause'] = self.option_menu_pause.get()
             config['last_overlapping'] = self.check_box_overlapping.get()
             config['last_timestamps'] = self.check_box_timestamps.get()
+            config['last_word_timestamps'] = self.check_box_word_timestamps.get()
             config['last_disfluencies'] = self.check_box_disfluencies.get()
             config['force_pyannote_cpu'] = str(force_pyannote_cpu)
             config['force_whisper_cpu'] = str(force_whisper_cpu)

--- a/tests/data/interview.vtt
+++ b/tests/data/interview.vtt
@@ -8,7 +8,7 @@ Transcribed with noScribe vers. 0.7 Audio file: ./Ein Gespräch mit Heikedine K�
 (12 seconds pause)
 
 2
-00:00:34.570 --> 00:00:35.790
+00:00:12.140 --> 00:00:35.790
 <v S01>Guten Tag, ich habe heute die große, einmalige Ehre, hier mit Heike Diene Költing zu sitzen, die, ja, Hörspielgöttin, die Hörspielqueen aus Deutschland sozusagen. (..) Erstmal, mir ist es eine große Ehre, Sie haben mir meine Kindheit auf jeden Fall versüßt. //S02: Ist das herrlich. // Ich kann das gar nicht in Worte fassen. //S00: Das ist doch Wunderbar. // Immer ein Wegbegleiter gewesen.
 
 3
@@ -20,19 +20,19 @@ Transcribed with noScribe vers. 0.7 Audio file: ./Ein Gespräch mit Heikedine K�
 <v S01>Können Sie sich aber noch an Ihr erstes Hörspiel erinnern?
 
 5
-00:00:59.630 --> 00:01:04.530
+00:00:39.650 --> 00:01:04.530
 <v S00>Ja, das kann ich noch sehr gut. Das war mein erstes Hörspiel bei der Kleine Seejungfrau. Ich bin ein Fan von den schönen Märchen von Andersen, alle so ein bisschen traurig, ein bisschen tragisch. Kleine Seejungfrau war mein allererstes und dann kamen noch mehrere von den Märchen und dann kamen meine erste Serie. Und da kommt ja ganz was Tolles, das müssen wir eigentlich unbedingt mit ins Bild bringen, was?
 
 6
-00:01:06.330 --> 00:01:07.410
+00:01:04.630 --> 00:01:07.410
 <v S01>Ist drin ein kleiner Scarecrow. Oje, meine Güte.
 
 7
-00:01:16.110 --> 00:01:20.430
+00:01:08.110 --> 00:01:20.430
 <v S00>Toll. Sag mal, ist er schick. Die Kleine Meerjungfrau. Ist das süß. //S02: Ja, die Kleine Seejungfrau, genau. // Und das ist ja auch ewig lange her und dann kam meine erste Serie mit Riepen.
 
 8
-00:01:23.670 --> 00:01:26.470
+00:01:20.930 --> 00:01:26.470
 <v S01>Ja, okay. Ja, fantastischer Hans-Karriker. //S00: Genau. // Haben wir heute gelernt, dass die auch bei den Masters mal mitgemacht hat.
 
 9
@@ -40,11 +40,11 @@ Transcribed with noScribe vers. 0.7 Audio file: ./Ein Gespräch mit Heikedine K�
 <v S00>Auch da hat er einmal mitgemacht.
 
 10
-00:01:38.210 --> 00:01:39.290
+00:01:28.270 --> 00:01:39.290
 <v S01>Kann man ja jetzt sagen, damals war das ja wegen GEMA-Gebühren und so ein bisschen schwieriger. //S00: Na ja, na ja, okay. (.) // Mein erstes Hörspiel war tatsächlich Fünf Freunde. Ich habe mit Fünf Freunden angefangen.
 
 11
-00:02:03.230 --> 00:02:07.190
+00:01:39.330 --> 00:02:07.190
 <v S00>Ach, ja, diese ersten fünf Freunde, die auch mit Helm gelaufen waren. //S01: Die ersten zwölf Folgen, ne? // Genau, das war eine großartige Frage. Und dann habe ich ja auch dann zugesehen, dass ich möglichst die Synchronsprecher kriege. Da war ja dann auch schon Oliver Rohrbeck dabei, den ich ja später als bei den Drei-Frage-Zeichen eingesetzt habe und Ute Rohrbeck und, ach, das war auch eine schöne Sache. Und außerdem würden die immer noch produzieren. Ich bin jetzt bei der Folge 150. //S01: Ach, tatsächlich? // Ja, wir feiern gerade ein Jubiläum mit 150 Folgen, Fünf Freunde.
 
 12
@@ -56,11 +56,11 @@ Transcribed with noScribe vers. 0.7 Audio file: ./Ein Gespräch mit Heikedine K�
 <v S00>Dann war man raus, klar, dann war man nicht zu alt geworden.
 
 14
-00:02:43.010 --> 00:02:47.970
+00:02:14.430 --> 00:02:47.970
 <v S01>Ja, nee, zu alt nicht, aber man hat halt andere Dinge entdeckt. Ich mache selber Musik und dann hat man sich da ein bisschen rein, vertieft und andere. Aber mittlerweile zum Einschlafen höre ich tatsächlich Masters. Ja? Das ist wirklich, das ist wirklich kein Witz. //S02: Das ist aber aufregend, ne? // Ja, ich finde das großartig. Das ist so ein, ja, so ein Stück Kindheit eigentlich. Jetzt aber mal ab von Masters hin zu was ganz anderem, Star Wars. Waren Sie da damals nicht interessiert oder dran, so was zu machen? Weil das war ja eigentlich, wäre ja genau ihr Ding gewesen, aber das war ja dann bei Philips.
 
 15
-00:03:26.470 --> 00:03:35.300
+00:02:48.530 --> 00:03:35.300
 <v S00>Ja, genau, genau, da haben die anderen schon vorweg, also sie haben wahrscheinlich mehr geboten oder ich weiß nicht mehr, wie es genau war. Aber auf jeden Fall war es ja so, dass manche auch ein bisschen Ressentiments haben vor einer 5D-Mark-Platte. Und dachten dann, ja, das ist dann vielleicht doch ein bisschen günstigere oder billigere Produktion. Ist es aber nie gewesen, denn wir haben ja im Gegensatz zu allen anderen nicht irgendwie eine Vorgabe gekriegt, jetzt hast du eine Woche Studio und dann wird die und die Folge fertig oder du hast 20 Stunden oder wie auch immer. Sondern wir konnten ja im eigenen Studio arbeiten von morgens bis abends und nachts und wann, Sonnabend und Sonntag und immer. Und haben eigentlich, würde ich mal sagen, auch rein technisch, eher, ich will nicht sagen besser, aber auf jeden Fall auch super gute Qualität gemacht.
 
 16
@@ -68,7 +68,7 @@ Transcribed with noScribe vers. 0.7 Audio file: ./Ein Gespräch mit Heikedine K�
 <v S01>Ja, was Sie erst mal auf Band machen, ne?
 
 17
-00:03:56.140 --> 00:04:02.560
+00:03:37.380 --> 00:04:02.560
 <v S00>Ja, und das Presswerk zum Beispiel, was ja in Quick Bonn war, also die eigene Publikation, kannst du ja heute sehen, wenn du die Schallplatten nochmal abhörst oder so, tip-tap, ne? //S01: Ja, also... // Wurden ja auch alle kontrolliert, also nicht jede einzelne, aber immer stichhaltig, so jede tausendste wurde rausgezogen und nochmal gehört. Und also ich habe jedenfalls noch meine alten Sachen und die sind noch wie vor, wie heute.
 
 18
@@ -76,11 +76,11 @@ Transcribed with noScribe vers. 0.7 Audio file: ./Ein Gespräch mit Heikedine K�
 <v S01>Ja, die Platten auch. Die sind ja ein bisschen gelitten in der Zeit, aber von außen, aber von innen sind die noch gut.
 
 19
-00:04:15.380 --> 00:04:19.680
+00:04:08.920 --> 00:04:19.680
 <v S00>Aber wie gesagt, das ist dann auch einfach... Wir haben ja sehr, sehr viel gemacht, sowieso. Und dann hat es dann vielleicht auch gar keinen Platz mehr gewesen. Ich weiß nicht mehr genau, wie es war, aber ich weiß, dass wir schon interessiert waren, klar.
 
 20
-00:04:25.340 --> 00:04:25.920
+00:04:20.480 --> 00:04:25.920
 <v //S02>Okay, also hat es dann einfach... War ein anderer schneller oder hat er... //S00: So genau, oder mehr gebogen. //S02: Also hat es daran gelegen.//
 
 21
@@ -88,11 +88,11 @@ Transcribed with noScribe vers. 0.7 Audio file: ./Ein Gespräch mit Heikedine K�
 <v S02>Ja, ja, ja.
 
 22
-00:04:40.720 --> 00:04:45.580
+00:04:26.620 --> 00:04:45.580
 <v S01>Jetzt aber die Frage, wo Sie das gerade sagten, dass Sie das ja in Ihrem eigenen Studio machen, etc. (..) eigentlich müssten Sie das ja nicht mehr machen. Was treibt Sie denn an, dann morgens aufzustehen und zu sagen, Sie haben auch immer so ein Lächeln drauf, Sie sind in der totale frohe Natur und sagen so, ach komm, heute machen wir das oder das oder das.
 
 23
-00:05:49.030 --> 00:05:50.930
+00:04:45.820 --> 00:05:50.930
 <v S00>Ja, also da brauchen wir ja bloß mal denken an vor einer halben Stunde, als ich die Möglichkeit hatte, damit euch oder vor euch auch die eine oder andere Frage zu beantworten. Wobei die anderen meistens besser wissen, als ich, weil ich so viel produziert habe, nicht mehr alles, alles, alles so genau erinnere. Aber wenn ich dann denke, wie ihr dann mir zugeklatscht habt und aufgestanden seid, Standing Ovations, also das ist schon ein Rückenriesen. Und wer hat das in meinem Alter, normalerweise würde man sagen, die Körtchen, ach guck mal, das ist die Oma, das ist eine nette Oma, so, ne? Ja, aber in dem Moment, wo die dann mitkriegen, die macht auch die Kleinen, die Jüngeren, ne? Die macht die Fragezeichen, die macht das und die hat Masters of the Universe gemacht und Flash Gordon und Huibu und Fünf Freunde und Drei Fragezeichen und was mehr alles, ne? Und Gruselserie und Macabros und Knight Rider. //S01: Ja, und großartig auch. // Ja, wenn die das dann hören, dann bin ich plötzlich eben nicht mehr die Umi Körting. Dann bin ich irgendwie interessant.
 
 24
@@ -100,7 +100,7 @@ Transcribed with noScribe vers. 0.7 Audio file: ./Ein Gespräch mit Heikedine K�
 <v S01>Für mich waren sie das nie.
 
 25
-00:05:57.870 --> 00:06:03.590
+00:05:52.890 --> 00:06:03.590
 <v S00>Haha, also ich weiß es ja jetzt, wir hatten gerade in der Waldbühne in Berlin die große Aufführung von Drei Fragezeichen mit immerhin 22.000 Leuten.
 
 26
@@ -108,31 +108,31 @@ Transcribed with noScribe vers. 0.7 Audio file: ./Ein Gespräch mit Heikedine K�
 <v S01>Das muss man sich mal überlegen für ein Hörspiel.
 
 27
-00:06:51.390 --> 00:06:52.870
+00:06:05.610 --> 00:06:52.870
 <v S00>Wahnsinn, für ein Hörspiel und dann, und das ist einfach, natürlich ein solches Gefühl kann man kaum mit irgendwas anderem vergleichen. Und was mich eben dann auch so sehr gefreut hat, da auch, dass eben auch ganz viele Junge, also eure Kinder, na, oder du bist ja noch zu jung für ein Kind, ne? //S01: Oh, danke, oh! (.) // Aber ich meine, eure Kinder oder die Nachfolgenden auch schon wieder sich dafür interessieren und dann macht natürlich auch die Arbeit mit den Künstlern ein Mordspaß. Ich habe ja eine ganze Menge abgelegt. Ich mache ja nur noch die vier Serien und eine kleine Hexe Lilly für die Kleinen noch und ein bisschen Grusel noch dazu. Aber sonst habe ich eigentlich nur die Folgen, die ich auch mal, ich will nicht sagen, ich groß gemacht habe, die jedenfalls sehr erfolgreich geworden sind, die habe ich alle noch in meinem Programm.
 
 28
-00:07:02.270 --> 00:07:05.250
+00:06:52.870 --> 00:07:05.250
 <v S01>Aber das ist auch schon mehr als genug. Ja gut, das bringt mich dann zu der Frage, gab es mal so eine Zeit, wo Sie am liebsten alles hingeworfen hätten? //S00: Nee. // Weil, gar nicht? Nicht mal so eine Produktion, wo gar nichts funktioniert hat?
 
 29
-00:08:54.710 --> 00:08:56.270
+00:07:05.250 --> 00:08:56.270
 <v S00>Nee, also nicht hingeworfen, aber ich ging davon aus, in den 90er Jahren, 2000, als wir vorher... //S01: Und das war eine schwierige Zeit. // Das war eine schwierige Zeit. Und ich hatte ja, habe ja eben auch noch einen anderen Beruf. Aber auf der anderen Seite hatte ich immer eigentlich Lust, schon als junges Mädchen, wollte ich gerne Filme machen. Und dann haben wir eine kleine Filmfirma gegründet. Und das war aber alles sehr aufwendig, war gar nicht so einfach wie im Tonstudio. Da kannst du nicht sagen, du arbeitest Tag und Nacht durch. Da brauchst du ja dann Techniker und Leute. Und dann muss man, die machen dann acht Stunden. Da musst du dann schon immer zwei oder drei nehmen, wenn du durcharbeiten willst. Und da war es dann eben so, dass wir eigentlich das Geld gewechselt haben, indem wir dann Werbung machen mussten. Das macht aber auf Dauer überhaupt keinen Spaß. Ich wollte ja richtig schöne Filme machen. Und in der Zwischenzeit, ja, hurra, plötzlich ging das los. Man wusste gar nicht, wieso. Plötzlich wurde wieder angezogen. Da wurden die Kassetten verkauft, CDs verkauft. Wir hatten ja bei den drei Fragezeichen beispielsweise die ersten 50 Folgen gar nicht mehr im Programm. Und ja, plötzlich kriegte man mit, das läuft wieder. Und es ist wieder gefragt. Da waren eben dann die zweite Generation, die ältere Generation, die sich erinnerte und sagte, Mensch, jetzt haben wir so viel Technisches und weiß echt was nicht alles Tolles. Aber was ist eigentlich so in meinem Herzen, was hat mir Freude gemacht? Und das ist natürlich so wie für mich bestimmte Bücher, Mistikchen, Fanny Nanny. Das waren so meine Kindheitserinnerungen. Da gab es ja noch keine, eine Schallplatte hatte ich, eine einzige. //S02: Welche war das? // Peter und der Wolf. Ah. Ja, Peter und der Wolf, die habe ich bestimmt auch tausendmal gehört. //S02: Ja. // Mit Matthias Wiemann. Ich habe sie ja später nochmal aufgenommen mit Hans Peetsch. Aber auch eine schöne Version. Ja, also das ist eigentlich der Grund. Es macht, es macht Freude. Ich werde noch gebraucht.
 
 30
-00:08:57.770 --> 00:08:58.810
+00:08:56.510 --> 00:08:58.810
 <v S01>Ja, absolut. Nicht wegzudenken.
 
 31
-00:09:02.610 --> 00:09:03.930
+00:08:58.810 --> 00:09:03.930
 <v S00>Ja, ich bin ja auch noch einigermaßen fit und das ist natürlich gut. Ich hoffe, das bleibt auch noch ein bisschen.
 
 32
-00:09:15.072 --> 00:09:16.190
+00:09:04.230 --> 00:09:16.190
 <v S01>Wo Sie gerade Neuauflagen angesprochen haben mit den drei Fragezeichen. //S00: Ja. // Jetzt ist ja Mattel wieder mit den Origins am Start. //S00: Ja. // Ja, da wäre doch eine Möglichkeit, die ganzen Sachen nochmal aufzunehmen. (.)
 
 33
-00:09:44.250 --> 00:09:47.590
+00:09:16.190 --> 00:09:47.590
 <v S00>Wäre natürlich schön. Aber? Alles, alles, also das ist ja nicht an mir, sondern es liegt meistens an den Rechten. Wir sind auch gerade dabei, wir haben auch jemanden aus der Firma, von Sony, jemanden, der jetzt speziell beauftragt ist, mit mir durchzusprechen. Was für Sachen haben wir eigentlich noch alles? Was haben wir noch alles an Lizenz- und Nicht-Lizenzprodukten? Welche könnten wir vielleicht nochmal auf den Markt bringen? Mit wem kann man verhandeln? Da sind wir schwer dabei und auch beim Masters of the Universe ist noch nicht das letzte Wort gesprochen, was nicht doch auch klappen könnte.
 
 34
@@ -140,7 +140,7 @@ Transcribed with noScribe vers. 0.7 Audio file: ./Ein Gespräch mit Heikedine K�
 <v S01>Also gibt es vielleicht die Chance, dass es das irgendwann mal auf Schallplatte gäbe?
 
 35
-00:09:57.190 --> 00:09:58.550
+00:09:51.530 --> 00:09:58.550
 <v S00>Ja, ich sehe hier gerade Kung-Fu, wer hat das mitgebracht? Ich hoffe, jeder kennt die. Sind die nicht toll?
 
 36
@@ -148,11 +148,11 @@ Transcribed with noScribe vers. 0.7 Audio file: ./Ein Gespräch mit Heikedine K�
 <v S01>Ja, großartig.
 
 37
-00:10:40.680 --> 00:10:43.120
+00:09:59.590 --> 00:10:43.120
 <v S00>Und das war, das war ganz spannend, da war ich in München mit meinem Mann bei einer Freundin und las in der Bild-Zeitung, glaube ich, Horst Frank verliebt in Brigitte Kollecker und süße Bilder auch von ihr, weil er eine bezaubernd hübsche Person und da habe ich gesagt, das ist die Gelegenheit, Horst kriege ich vielleicht so leicht nicht allein, aber wenn wir die im Doppelpunkt haben. Ah, über die Hintertür, nein, ja, ja, ja, ja, genau, genau, ja, und dann, und bei der Gelegenheit habe ich dann, und dann haben wir das sogar in München aufgenommen, relativ spontan. Ach, gar nicht, gar nicht in Ihrem Studien? Nein, nein, das haben wir aber dann in unserem Studium dann nachbearbeitet. Ja, ja, ja. Ja, ich habe gerade gesehen.
 
 38
-00:10:44.340 --> 00:10:45.856
+00:10:43.500 --> 00:10:45.856
 <v S01>Ja, und zwar? (..)
 
 39
@@ -160,7 +160,7 @@ Transcribed with noScribe vers. 0.7 Audio file: ./Ein Gespräch mit Heikedine K�
 <v S00>Ich muss zum Zug.
 
 40
-00:10:51.250 --> 00:10:52.050
+00:10:46.850 --> 00:10:52.050
 <v //S00>Ah, okay, dann kommen wir langsam, dann kommen wir langsam zu Ende, aber ich lasse es mir //S00: natürlich nicht nehmen.//
 
 41
@@ -168,7 +168,7 @@ Transcribed with noScribe vers. 0.7 Audio file: ./Ein Gespräch mit Heikedine K�
 <v S00>Aber ich komme wieder, es war so nett.
 
 42
-00:10:58.430 --> 00:11:00.990
+00:10:53.970 --> 00:11:00.990
 <v S01>Ich lasse es mir natürlich nicht nehmen, diese beiden Platten von Ihnen bitte noch signieren zu lassen. //S00: Genau. // Damit die einen würdigen Platz in meinem Plattenregal finden.
 
 43
@@ -184,7 +184,7 @@ Transcribed with noScribe vers. 0.7 Audio file: ./Ein Gespräch mit Heikedine K�
 <v S00>Oder nur Heike-Diene-Fabrik?
 
 46
-00:11:08.480 --> 00:11:09.480
+00:11:04.450 --> 00:11:09.480
 <v S01>Ja, einfach Heike-Diene-Karting drauf. Das ist super. Das mache ich doch gerne. Das macht...
 
 47
@@ -192,7 +192,7 @@ Transcribed with noScribe vers. 0.7 Audio file: ./Ein Gespräch mit Heikedine K�
 <v S00>Also, ich liebe die, also, die kann ich auch noch auswendig.
 
 48
-00:11:14.784 --> 00:11:15.904
+00:11:13.160 --> 00:11:15.904
 <v S01>Und natürlich den Kabaden. (.)
 
 49
@@ -200,15 +200,15 @@ Transcribed with noScribe vers. 0.7 Audio file: ./Ein Gespräch mit Heikedine K�
 <v S00>Der wird mit Rot unterschrieben.
 
 50
-00:11:19.620 --> 00:11:21.792
+00:11:17.440 --> 00:11:21.792
 <v S01>Ja, Rot auf Blau, das ist doch super. (..)
 
 51
-00:11:35.660 --> 00:11:37.200
+00:11:21.792 --> 00:11:37.200
 <v S00>Ja, ich komme ja aus Hamburg und habe jetzt fünfeinhalb Stunden Zugfahrt. Zugfahrt. //S01: Oh mein Gott. Oh mein Gott. Ja. // Aber das habe ich gern gemacht, habe ich gern gemacht, was, wie gesagt, hat mir richtig doll Freude gemacht. Für DSD. (..)
 
 52
-00:11:59.620 --> 00:12:01.740
+00:11:37.200 --> 00:12:01.740
 <v S01>Für DSD. Groß? Ja, ja, alles groß, große Lettern. Dann haben wir hier noch die Autogrammstunde, die private sozusagen. Die Frau Körting geht hier zum Zug. Ich danke vielmals für dieses kleine Gespräch. Das bedeutet mir wirklich sehr viel, dass Sie sich dafür Zeit genommen haben. Wünsche Ihnen eine gesunde und gute Rückfahrt nach Hamburg. Ja. Ist ja nicht so gerade um die Ecke. Nee. Und dann hoffe ich, dass wir uns vielleicht irgendwann mal wiedersehen.
 
 53
@@ -220,10 +220,10 @@ Transcribed with noScribe vers. 0.7 Audio file: ./Ein Gespräch mit Heikedine K�
 <v S01>Ja.
 
 55
-00:12:04.660 --> 00:12:06.160
+00:12:03.060 --> 00:12:06.160
 <v S00>Ich freue mich. //S01: Vielen lieben Dank. // Ganz, ganz große Freude.
 
 56
-00:12:17.141 --> 00:12:15.168
+00:12:06.460 --> 00:12:15.168
 <v S01>Oh, wir haben sogar Puppetum gemacht. So, zu viel Internet ist aber ungesund und deswegen könnt ihr jetzt was genau richtig abschalten. Abschalten, abschalten, abschalten, abschalten, abschalten. (..) Ja.
 

--- a/trans/noScribe.de.yml
+++ b/trans/noScribe.de.yml
@@ -43,6 +43,7 @@ de:
   label_overlapping: 'Überlappende Sprache:'
   label_pause: 'Pausen markieren:'
   label_timestamps: 'Zeitmarken:'
+  label_word_timestamps: 'Wortgenaue Zeitmarken:'
   label_disfluencies: 'Füllworte:'
 
   start_button: Start

--- a/trans/noScribe.en.yml
+++ b/trans/noScribe.en.yml
@@ -44,6 +44,7 @@ en:
   label_overlapping: 'Overlapping speech:'
   label_pause: 'Mark pause:'
   label_timestamps: 'Timestamps:'
+  label_word_timestamps: 'Word-level timestamps:'
   label_disfluencies: 'Disfluencies:'
   
   start_button: Start 

--- a/trans/noScribe.es.yml
+++ b/trans/noScribe.es.yml
@@ -42,6 +42,7 @@ es:
   label_overlapping: 'Discurso solapado:'
   label_pause: 'Marca pausas:'
   label_timestamps: 'Timestamps:'
+  label_word_timestamps: 'Marcas de tiempo por palabra:'
   label_disfluencies: 'Disfluencias:'
   
   start_button: Iniciar

--- a/trans/noScribe.fr.yml
+++ b/trans/noScribe.fr.yml
@@ -42,6 +42,7 @@ fr:
   label_overlapping: 'Chevauchements de parole'
   label_pause: 'Marquer les pauses :'
   label_timestamps: 'Horodatage :'
+  label_word_timestamps: 'Horodatage au niveau du mot :'
   label_disfluencies: 'Mots de remplissage :'
   
   start_button: "Démarrer"

--- a/trans/noScribe.it.yml
+++ b/trans/noScribe.it.yml
@@ -42,6 +42,7 @@ it:
   label_overlapping: 'Discorso sovrapposto:'
   label_pause: 'Segna le pause:'
   label_timestamps: 'Timestamps:'
+  label_word_timestamps: 'Timestamp a livello di parola:'
   label_disfluencies: 'Disfluenze:'
   
   start_button: Avvia

--- a/trans/noScribe.ja.yml
+++ b/trans/noScribe.ja.yml
@@ -43,6 +43,7 @@ ja:
   label_overlapping: 'オーバーラッピング・スピーチ：'
   label_pause: 'マークはポーズをとる：'
   label_timestamps: 'タイムスタンプ：'
+  label_word_timestamps: '単語レベルのタイムスタンプ：'
   label_disfluencies: 'フィラー：'
 
   start_button: 開始

--- a/trans/noScribe.pt.yml
+++ b/trans/noScribe.pt.yml
@@ -43,6 +43,7 @@ pt:
   label_overlapping: 'Sobreposição:'
   label_pause: 'Marcar pausas:'
   label_timestamps: 'Registos temporais:'
+  label_word_timestamps: 'Marcações temporais por palavra:'
   label_disfluencies: 'Disfluências:'
   
   start_button: Iniciar

--- a/trans/noScribe.ru.yml
+++ b/trans/noScribe.ru.yml
@@ -43,6 +43,7 @@ ru:
   label_overlapping: 'Перекрытие речи:'
   label_pause: 'Отметьте паузы:'
   label_timestamps: 'Временные метки:'
+  label_word_timestamps: 'Временные метки на уровне слов:'
   label_disfluencies: 'Паразитные слова:'
   
   start_button: Старт

--- a/trans/noScribe.zh-CN.yml
+++ b/trans/noScribe.zh-CN.yml
@@ -42,6 +42,7 @@ zh-CN: &defaults
   label_overlapping: '重叠发言：'
   label_pause: '标记停顿：'
   label_timestamps: '时间戳：'
+  label_word_timestamps: '词级时间戳：'
   label_disfluencies: '语言停顿：'
   
   start_button: 开始 

--- a/utils.py
+++ b/utils.py
@@ -299,9 +299,15 @@ def html_to_webvtt(html_string: str) -> str:
                 for item in attrs:
                     if item[0] == "name":
                         tmp = item[1].split("_")
-                self.segments[-1]["time_start"] = tmp[1]
-                self.segments[-1]["time_end"] = tmp[2]
-                self.segments[-1]["speaker"] = tmp[3]
+                if tmp:
+                    # First anchor in a paragraph sets the cue start time;
+                    # every anchor updates the cue end (last anchor wins).
+                    # This is a no-op for single-anchor paragraphs and correctly
+                    # spans first-to-last word for word-level anchor paragraphs.
+                    if self.segments[-1]["time_start"] is None:
+                        self.segments[-1]["time_start"] = tmp[1]
+                    self.segments[-1]["time_end"] = tmp[2]
+                    self.segments[-1]["speaker"] = tmp[3]
 
         def handle_endtag(self, tag):
             pass


### PR DESCRIPTION
Adds a checkbox to the interface. If ticked, word-level timestamps are used for the html (and exports). Important: This still has bugs and is not reliable, thus highly experimental. This merge request is meant as a first step towards implementing the feature. 

Known issues if the checkbox "word-level timestamps" is ticked: 
- Overlaps are not reliably identified (anymore)
- .vtt export has one speaker only (if .vtt is imported into ELAN, I did not check the file itself).

I hope this is somehow helpful to get this feature into noScribe. 

Disclaimer for transparency: I used Claude Code for (some) of these code changes.