### PR TITLE
Fix failing pytest: regenerate stale WebVTT test fixture

### DIFF
--- a/tests/data/interview.vtt
+++ b/tests/data/interview.vtt
@@ -8,222 +8,994 @@ Transcribed with noScribe vers. 0.7 Audio file: ./Ein Gespräch mit Heikedine K�
 (12 seconds pause)
 
 2
-00:00:34.570 --> 00:00:35.790
-<v S01>Guten Tag, ich habe heute die große, einmalige Ehre, hier mit Heike Diene Költing zu sitzen, die, ja, Hörspielgöttin, die Hörspielqueen aus Deutschland sozusagen. (..) Erstmal, mir ist es eine große Ehre, Sie haben mir meine Kindheit auf jeden Fall versüßt. //S02: Ist das herrlich. // Ich kann das gar nicht in Worte fassen. //S00: Das ist doch Wunderbar. // Immer ein Wegbegleiter gewesen.
+00:00:12.140 --> 00:00:22.800
+<v S01>Guten Tag, ich habe heute die große, einmalige Ehre, hier mit Heike Diene Költing zu sitzen, die, ja, Hörspielgöttin, die Hörspielqueen aus Deutschland sozusagen.
 
 3
+00:00:22.800 --> 00:00:24.360
+<v S01>(..)
+
+4
+00:00:24.360 --> 00:00:30.010
+<v S01>Erstmal, mir ist es eine große Ehre, Sie haben mir meine Kindheit auf jeden Fall versüßt.
+
+5
+00:00:30.090 --> 00:00:30.910
+<v //S02>//S02: Ist das herrlich.
+
+6
+00:00:31.870 --> 00:00:33.510
+<v S01>// Ich kann das gar nicht in Worte fassen.
+
+7
+00:00:33.750 --> 00:00:34.570
+<v //S00>//S00: Das ist doch Wunderbar.
+
+8
+00:00:34.570 --> 00:00:35.790
+<v S01>// Immer ein Wegbegleiter gewesen.
+
+9
 00:00:36.190 --> 00:00:36.330
 <v S00>Ja.
 
-4
+10
 00:00:36.950 --> 00:00:39.650
 <v S01>Können Sie sich aber noch an Ihr erstes Hörspiel erinnern?
 
-5
+11
+00:00:39.650 --> 00:00:43.610
+<v S00>Ja, das kann ich noch sehr gut. Das war mein erstes Hörspiel bei der Kleine Seejungfrau.
+
+12
+00:00:43.690 --> 00:00:49.350
+<v S00>Ich bin ein Fan von den schönen Märchen von Andersen, alle so ein bisschen traurig, ein bisschen tragisch.
+
+13
+00:00:49.750 --> 00:00:59.250
+<v S00>Kleine Seejungfrau war mein allererstes und dann kamen noch mehrere von den Märchen und dann kamen meine erste Serie.
+
+14
 00:00:59.630 --> 00:01:04.530
-<v S00>Ja, das kann ich noch sehr gut. Das war mein erstes Hörspiel bei der Kleine Seejungfrau. Ich bin ein Fan von den schönen Märchen von Andersen, alle so ein bisschen traurig, ein bisschen tragisch. Kleine Seejungfrau war mein allererstes und dann kamen noch mehrere von den Märchen und dann kamen meine erste Serie. Und da kommt ja ganz was Tolles, das müssen wir eigentlich unbedingt mit ins Bild bringen, was?
+<v S00>Und da kommt ja ganz was Tolles, das müssen wir eigentlich unbedingt mit ins Bild bringen, was?
 
-6
+15
+00:01:04.630 --> 00:01:06.130
+<v S01>Ist drin ein kleiner Scarecrow.
+
+16
 00:01:06.330 --> 00:01:07.410
-<v S01>Ist drin ein kleiner Scarecrow. Oje, meine Güte.
+<v S01>Oje, meine Güte.
 
-7
+17
+00:01:08.110 --> 00:01:08.550
+<v S00>Toll.
+
+18
+00:01:08.550 --> 00:01:10.624
+<v S00>Sag mal, ist er schick.
+
+19
+00:01:11.488 --> 00:01:12.490
+<v S00>Die Kleine Meerjungfrau.
+
+20
+00:01:12.510 --> 00:01:13.330
+<v S00>Ist das süß.
+
+21
+00:01:13.470 --> 00:01:15.350
+<v //S02>//S02: Ja, die Kleine Seejungfrau, genau.
+
+22
 00:01:16.110 --> 00:01:20.430
-<v S00>Toll. Sag mal, ist er schick. Die Kleine Meerjungfrau. Ist das süß. //S02: Ja, die Kleine Seejungfrau, genau. // Und das ist ja auch ewig lange her und dann kam meine erste Serie mit Riepen.
+<v S00>// Und das ist ja auch ewig lange her und dann kam meine erste Serie mit Riepen.
 
-8
+23
+00:01:20.930 --> 00:01:21.530
+<v S01>Ja, okay.
+
+24
+00:01:21.870 --> 00:01:23.390
+<v S01>Ja, fantastischer Hans-Karriker.
+
+25
+00:01:23.510 --> 00:01:23.670
+<v //S00>//S00: Genau.
+
+26
 00:01:23.670 --> 00:01:26.470
-<v S01>Ja, okay. Ja, fantastischer Hans-Karriker. //S00: Genau. // Haben wir heute gelernt, dass die auch bei den Masters mal mitgemacht hat.
+<v S01>// Haben wir heute gelernt, dass die auch bei den Masters mal mitgemacht hat.
 
-9
+27
 00:01:26.490 --> 00:01:28.190
 <v S00>Auch da hat er einmal mitgemacht.
 
-10
+28
+00:01:28.270 --> 00:01:33.170
+<v S01>Kann man ja jetzt sagen, damals war das ja wegen GEMA-Gebühren und so ein bisschen schwieriger.
+
+29
+00:01:33.170 --> 00:01:34.150
+<v //S00>//S00: Na ja, na ja, okay.
+
+30
+00:01:34.150 --> 00:01:35.590
+<v //S00>(.)
+
+31
+00:01:35.590 --> 00:01:37.850
+<v S01>// Mein erstes Hörspiel war tatsächlich Fünf Freunde.
+
+32
 00:01:38.210 --> 00:01:39.290
-<v S01>Kann man ja jetzt sagen, damals war das ja wegen GEMA-Gebühren und so ein bisschen schwieriger. //S00: Na ja, na ja, okay. (.) // Mein erstes Hörspiel war tatsächlich Fünf Freunde. Ich habe mit Fünf Freunden angefangen.
+<v S01>Ich habe mit Fünf Freunden angefangen.
 
-11
+33
+00:01:39.330 --> 00:01:42.130
+<v S00>Ach, ja, diese ersten fünf Freunde, die auch mit Helm gelaufen waren.
+
+34
+00:01:42.310 --> 00:01:43.530
+<v //S01>//S01: Die ersten zwölf Folgen, ne?
+
+35
+00:01:43.590 --> 00:01:45.090
+<v S00>// Genau, das war eine großartige Frage.
+
+36
+00:01:45.090 --> 00:01:48.690
+<v S00>Und dann habe ich ja auch dann zugesehen, dass ich möglichst die Synchronsprecher kriege.
+
+37
+00:01:48.830 --> 00:01:53.750
+<v S00>Da war ja dann auch schon Oliver Rohrbeck dabei, den ich ja später als bei den Drei-Frage-Zeichen
+
+38
+00:01:53.750 --> 00:01:57.970
+<v S00>eingesetzt habe und Ute Rohrbeck und, ach, das war auch eine schöne Sache.
+
+39
+00:01:58.190 --> 00:02:00.350
+<v S00>Und außerdem würden die immer noch produzieren.
+
+40
+00:02:00.470 --> 00:02:02.210
+<v S00>Ich bin jetzt bei der Folge 150.
+
+41
+00:02:02.510 --> 00:02:02.930
+<v //S01>//S01: Ach, tatsächlich?
+
+42
 00:02:03.230 --> 00:02:07.190
-<v S00>Ach, ja, diese ersten fünf Freunde, die auch mit Helm gelaufen waren. //S01: Die ersten zwölf Folgen, ne? // Genau, das war eine großartige Frage. Und dann habe ich ja auch dann zugesehen, dass ich möglichst die Synchronsprecher kriege. Da war ja dann auch schon Oliver Rohrbeck dabei, den ich ja später als bei den Drei-Frage-Zeichen eingesetzt habe und Ute Rohrbeck und, ach, das war auch eine schöne Sache. Und außerdem würden die immer noch produzieren. Ich bin jetzt bei der Folge 150. //S01: Ach, tatsächlich? // Ja, wir feiern gerade ein Jubiläum mit 150 Folgen, Fünf Freunde.
+<v S00>// Ja, wir feiern gerade ein Jubiläum mit 150 Folgen, Fünf Freunde.
 
-12
+43
 00:02:07.370 --> 00:02:11.950
 <v S01>Ach, ich war, ich habe vielleicht die ersten 20, 30, ja gut, dann war man halt so ein bisschen raus.
 
-13
+44
 00:02:11.950 --> 00:02:14.430
 <v S00>Dann war man raus, klar, dann war man nicht zu alt geworden.
 
-14
+45
+00:02:14.430 --> 00:02:17.330
+<v S01>Ja, nee, zu alt nicht, aber man hat halt andere Dinge entdeckt.
+
+46
+00:02:17.410 --> 00:02:22.410
+<v S01>Ich mache selber Musik und dann hat man sich da ein bisschen rein, vertieft und andere.
+
+47
+00:02:22.990 --> 00:02:25.330
+<v S01>Aber mittlerweile zum Einschlafen höre ich tatsächlich Masters.
+
+48
+00:02:25.670 --> 00:02:25.890
+<v S01>Ja?
+
+49
+00:02:25.930 --> 00:02:27.770
+<v S01>Das ist wirklich, das ist wirklich kein Witz.
+
+50
+00:02:28.050 --> 00:02:29.330
+<v //S02>//S02: Das ist aber aufregend, ne?
+
+51
+00:02:29.330 --> 00:02:30.730
+<v S01>// Ja, ich finde das großartig.
+
+52
+00:02:30.830 --> 00:02:33.250
+<v S01>Das ist so ein, ja, so ein Stück Kindheit eigentlich.
+
+53
+00:02:33.870 --> 00:02:38.530
+<v S01>Jetzt aber mal ab von Masters hin zu was ganz anderem, Star Wars.
+
+54
+00:02:39.210 --> 00:02:43.010
+<v S01>Waren Sie da damals nicht interessiert oder dran, so was zu machen?
+
+55
 00:02:43.010 --> 00:02:47.970
-<v S01>Ja, nee, zu alt nicht, aber man hat halt andere Dinge entdeckt. Ich mache selber Musik und dann hat man sich da ein bisschen rein, vertieft und andere. Aber mittlerweile zum Einschlafen höre ich tatsächlich Masters. Ja? Das ist wirklich, das ist wirklich kein Witz. //S02: Das ist aber aufregend, ne? // Ja, ich finde das großartig. Das ist so ein, ja, so ein Stück Kindheit eigentlich. Jetzt aber mal ab von Masters hin zu was ganz anderem, Star Wars. Waren Sie da damals nicht interessiert oder dran, so was zu machen? Weil das war ja eigentlich, wäre ja genau ihr Ding gewesen, aber das war ja dann bei Philips.
+<v S01>Weil das war ja eigentlich, wäre ja genau ihr Ding gewesen, aber das war ja dann bei Philips.
 
-15
+56
+00:02:48.530 --> 00:02:53.610
+<v S00>Ja, genau, genau, da haben die anderen schon vorweg, also sie haben wahrscheinlich mehr geboten oder ich weiß nicht mehr, wie es genau war.
+
+57
+00:02:53.890 --> 00:03:01.690
+<v S00>Aber auf jeden Fall war es ja so, dass manche auch ein bisschen Ressentiments haben vor einer 5D-Mark-Platte.
+
+58
+00:03:01.690 --> 00:03:06.470
+<v S00>Und dachten dann, ja, das ist dann vielleicht doch ein bisschen günstigere oder billigere Produktion.
+
+59
+00:03:06.590 --> 00:03:12.730
+<v S00>Ist es aber nie gewesen, denn wir haben ja im Gegensatz zu allen anderen nicht irgendwie eine Vorgabe gekriegt,
+
+60
+00:03:13.250 --> 00:03:18.770
+<v S00>jetzt hast du eine Woche Studio und dann wird die und die Folge fertig oder du hast 20 Stunden oder wie auch immer.
+
+61
+00:03:18.770 --> 00:03:25.870
+<v S00>Sondern wir konnten ja im eigenen Studio arbeiten von morgens bis abends und nachts und wann, Sonnabend und Sonntag und immer.
+
+62
 00:03:26.470 --> 00:03:35.300
-<v S00>Ja, genau, genau, da haben die anderen schon vorweg, also sie haben wahrscheinlich mehr geboten oder ich weiß nicht mehr, wie es genau war. Aber auf jeden Fall war es ja so, dass manche auch ein bisschen Ressentiments haben vor einer 5D-Mark-Platte. Und dachten dann, ja, das ist dann vielleicht doch ein bisschen günstigere oder billigere Produktion. Ist es aber nie gewesen, denn wir haben ja im Gegensatz zu allen anderen nicht irgendwie eine Vorgabe gekriegt, jetzt hast du eine Woche Studio und dann wird die und die Folge fertig oder du hast 20 Stunden oder wie auch immer. Sondern wir konnten ja im eigenen Studio arbeiten von morgens bis abends und nachts und wann, Sonnabend und Sonntag und immer. Und haben eigentlich, würde ich mal sagen, auch rein technisch, eher, ich will nicht sagen besser, aber auf jeden Fall auch super gute Qualität gemacht.
+<v S00>Und haben eigentlich, würde ich mal sagen, auch rein technisch, eher, ich will nicht sagen besser, aber auf jeden Fall auch super gute Qualität gemacht.
 
-16
+63
 00:03:35.840 --> 00:03:37.380
 <v S01>Ja, was Sie erst mal auf Band machen, ne?
 
-17
-00:03:56.140 --> 00:04:02.560
-<v S00>Ja, und das Presswerk zum Beispiel, was ja in Quick Bonn war, also die eigene Publikation, kannst du ja heute sehen, wenn du die Schallplatten nochmal abhörst oder so, tip-tap, ne? //S01: Ja, also... // Wurden ja auch alle kontrolliert, also nicht jede einzelne, aber immer stichhaltig, so jede tausendste wurde rausgezogen und nochmal gehört. Und also ich habe jedenfalls noch meine alten Sachen und die sind noch wie vor, wie heute.
+64
+00:03:37.380 --> 00:03:41.880
+<v S00>Ja, und das Presswerk zum Beispiel, was ja in Quick Bonn war, also die eigene Publikation,
 
-18
+65
+00:03:42.440 --> 00:03:47.040
+<v S00>kannst du ja heute sehen, wenn du die Schallplatten nochmal abhörst oder so, tip-tap, ne?
+
+66
+00:03:47.060 --> 00:03:47.460
+<v //S01>//S01: Ja, also...
+
+67
+00:03:47.460 --> 00:03:55.200
+<v S00>// Wurden ja auch alle kontrolliert, also nicht jede einzelne, aber immer stichhaltig, so jede tausendste wurde rausgezogen und nochmal gehört.
+
+68
+00:03:56.140 --> 00:04:02.560
+<v S00>Und also ich habe jedenfalls noch meine alten Sachen und die sind noch wie vor, wie heute.
+
+69
 00:04:02.560 --> 00:04:07.940
 <v S01>Ja, die Platten auch. Die sind ja ein bisschen gelitten in der Zeit, aber von außen, aber von innen sind die noch gut.
 
-19
+70
+00:04:08.920 --> 00:04:13.260
+<v S00>Aber wie gesagt, das ist dann auch einfach... Wir haben ja sehr, sehr viel gemacht, sowieso.
+
+71
+00:04:13.440 --> 00:04:15.300
+<v S00>Und dann hat es dann vielleicht auch gar keinen Platz mehr gewesen.
+
+72
 00:04:15.380 --> 00:04:19.680
-<v S00>Aber wie gesagt, das ist dann auch einfach... Wir haben ja sehr, sehr viel gemacht, sowieso. Und dann hat es dann vielleicht auch gar keinen Platz mehr gewesen. Ich weiß nicht mehr genau, wie es war, aber ich weiß, dass wir schon interessiert waren, klar.
+<v S00>Ich weiß nicht mehr genau, wie es war, aber ich weiß, dass wir schon interessiert waren, klar.
 
-20
+73
+00:04:20.480 --> 00:04:23.940
+<v S01>Okay, also hat es dann einfach... War ein anderer schneller oder hat er...
+
+74
+00:04:23.940 --> 00:04:24.980
+<v //S00>//S00: So genau, oder mehr gebogen.
+
+75
 00:04:25.340 --> 00:04:25.920
-<v //S02>Okay, also hat es dann einfach... War ein anderer schneller oder hat er... //S00: So genau, oder mehr gebogen. //S02: Also hat es daran gelegen.//
+<v //S02>//S02: Also hat es daran gelegen.//
 
-21
+76
 00:04:25.980 --> 00:04:26.340
 <v S02>Ja, ja, ja.
 
-22
+77
+00:04:26.620 --> 00:04:31.620
+<v S01>Jetzt aber die Frage, wo Sie das gerade sagten, dass Sie das ja in Ihrem eigenen Studio machen, etc.
+
+78
+00:04:31.620 --> 00:04:33.340
+<v S01>(..)
+
+79
+00:04:33.340 --> 00:04:35.260
+<v S01>eigentlich müssten Sie das ja nicht mehr machen.
+
+80
+00:04:35.500 --> 00:04:40.520
+<v S01>Was treibt Sie denn an, dann morgens aufzustehen und zu sagen, Sie haben auch immer so ein Lächeln drauf,
+
+81
 00:04:40.720 --> 00:04:45.580
-<v S01>Jetzt aber die Frage, wo Sie das gerade sagten, dass Sie das ja in Ihrem eigenen Studio machen, etc. (..) eigentlich müssten Sie das ja nicht mehr machen. Was treibt Sie denn an, dann morgens aufzustehen und zu sagen, Sie haben auch immer so ein Lächeln drauf, Sie sind in der totale frohe Natur und sagen so, ach komm, heute machen wir das oder das oder das.
+<v S01>Sie sind in der totale frohe Natur und sagen so, ach komm, heute machen wir das oder das oder das.
 
-23
+82
+00:04:45.820 --> 00:04:51.500
+<v S00>Ja, also da brauchen wir ja bloß mal denken an vor einer halben Stunde, als ich die Möglichkeit hatte,
+
+83
+00:04:51.880 --> 00:04:56.420
+<v S00>damit euch oder vor euch auch die eine oder andere Frage zu beantworten.
+
+84
+00:04:56.420 --> 00:05:00.160
+<v S00>Wobei die anderen meistens besser wissen, als ich, weil ich so viel produziert habe,
+
+85
+00:05:00.520 --> 00:05:02.440
+<v S00>nicht mehr alles, alles, alles so genau erinnere.
+
+86
+00:05:02.780 --> 00:05:10.290
+<v S00>Aber wenn ich dann denke, wie ihr dann mir zugeklatscht habt und aufgestanden seid,
+
+87
+00:05:10.470 --> 00:05:14.070
+<v S00>Standing Ovations, also das ist schon ein Rückenriesen.
+
+88
+00:05:14.070 --> 00:05:18.530
+<v S00>Und wer hat das in meinem Alter, normalerweise würde man sagen, die Körtchen,
+
+89
+00:05:18.750 --> 00:05:21.430
+<v S00>ach guck mal, das ist die Oma, das ist eine nette Oma, so, ne?
+
+90
+00:05:21.690 --> 00:05:27.170
+<v S00>Ja, aber in dem Moment, wo die dann mitkriegen, die macht auch die Kleinen, die Jüngeren, ne?
+
+91
+00:05:27.530 --> 00:05:32.310
+<v S00>Die macht die Fragezeichen, die macht das und die hat Masters of the Universe gemacht
+
+92
+00:05:32.310 --> 00:05:37.410
+<v S00>und Flash Gordon und Huibu und Fünf Freunde und Drei Fragezeichen und was mehr alles, ne?
+
+93
+00:05:37.410 --> 00:05:41.450
+<v S00>Und Gruselserie und Macabros und Knight Rider.
+
+94
+00:05:41.750 --> 00:05:42.570
+<v //S01>//S01: Ja, und großartig auch.
+
+95
+00:05:42.590 --> 00:05:48.550
+<v S00>// Ja, wenn die das dann hören, dann bin ich plötzlich eben nicht mehr die Umi Körting.
+
+96
 00:05:49.030 --> 00:05:50.930
-<v S00>Ja, also da brauchen wir ja bloß mal denken an vor einer halben Stunde, als ich die Möglichkeit hatte, damit euch oder vor euch auch die eine oder andere Frage zu beantworten. Wobei die anderen meistens besser wissen, als ich, weil ich so viel produziert habe, nicht mehr alles, alles, alles so genau erinnere. Aber wenn ich dann denke, wie ihr dann mir zugeklatscht habt und aufgestanden seid, Standing Ovations, also das ist schon ein Rückenriesen. Und wer hat das in meinem Alter, normalerweise würde man sagen, die Körtchen, ach guck mal, das ist die Oma, das ist eine nette Oma, so, ne? Ja, aber in dem Moment, wo die dann mitkriegen, die macht auch die Kleinen, die Jüngeren, ne? Die macht die Fragezeichen, die macht das und die hat Masters of the Universe gemacht und Flash Gordon und Huibu und Fünf Freunde und Drei Fragezeichen und was mehr alles, ne? Und Gruselserie und Macabros und Knight Rider. //S01: Ja, und großartig auch. // Ja, wenn die das dann hören, dann bin ich plötzlich eben nicht mehr die Umi Körting. Dann bin ich irgendwie interessant.
+<v S00>Dann bin ich irgendwie interessant.
 
-24
+97
 00:05:51.550 --> 00:05:52.570
 <v S01>Für mich waren sie das nie.
 
-25
-00:05:57.870 --> 00:06:03.590
-<v S00>Haha, also ich weiß es ja jetzt, wir hatten gerade in der Waldbühne in Berlin die große Aufführung von Drei Fragezeichen mit immerhin 22.000 Leuten.
+98
+00:05:52.890 --> 00:05:57.870
+<v S00>Haha, also ich weiß es ja jetzt, wir hatten gerade in der Waldbühne in Berlin
 
-26
+99
+00:05:57.870 --> 00:06:03.590
+<v S00>die große Aufführung von Drei Fragezeichen mit immerhin 22.000 Leuten.
+
+100
 00:06:03.690 --> 00:06:05.610
 <v S01>Das muss man sich mal überlegen für ein Hörspiel.
 
-27
+101
+00:06:05.610 --> 00:06:10.570
+<v S00>Wahnsinn, für ein Hörspiel und dann, und das ist einfach, natürlich ein solches Gefühl
+
+102
+00:06:10.570 --> 00:06:12.550
+<v S00>kann man kaum mit irgendwas anderem vergleichen.
+
+103
+00:06:12.730 --> 00:06:18.250
+<v S00>Und was mich eben dann auch so sehr gefreut hat, da auch, dass eben auch ganz viele Junge,
+
+104
+00:06:18.450 --> 00:06:21.130
+<v S00>also eure Kinder, na, oder du bist ja noch zu jung für ein Kind, ne?
+
+105
+00:06:21.510 --> 00:06:22.830
+<v //S01>//S01: Oh, danke, oh!
+
+106
+00:06:22.830 --> 00:06:23.968
+<v //S01>(.)
+
+107
+00:06:23.968 --> 00:06:30.150
+<v S00>// Aber ich meine, eure Kinder oder die Nachfolgenden auch schon wieder sich dafür interessieren
+
+108
+00:06:30.150 --> 00:06:34.230
+<v S00>und dann macht natürlich auch die Arbeit mit den Künstlern ein Mordspaß.
+
+109
+00:06:34.230 --> 00:06:35.650
+<v S00>Ich habe ja eine ganze Menge abgelegt.
+
+110
+00:06:35.770 --> 00:06:41.090
+<v S00>Ich mache ja nur noch die vier Serien und eine kleine Hexe Lilly für die Kleinen noch
+
+111
+00:06:41.090 --> 00:06:42.770
+<v S00>und ein bisschen Grusel noch dazu.
+
+112
+00:06:42.970 --> 00:06:47.590
+<v S00>Aber sonst habe ich eigentlich nur die Folgen, die ich auch mal, ich will nicht sagen,
+
+113
+00:06:47.790 --> 00:06:50.930
+<v S00>ich groß gemacht habe, die jedenfalls sehr erfolgreich geworden sind,
+
+114
 00:06:51.390 --> 00:06:52.870
-<v S00>Wahnsinn, für ein Hörspiel und dann, und das ist einfach, natürlich ein solches Gefühl kann man kaum mit irgendwas anderem vergleichen. Und was mich eben dann auch so sehr gefreut hat, da auch, dass eben auch ganz viele Junge, also eure Kinder, na, oder du bist ja noch zu jung für ein Kind, ne? //S01: Oh, danke, oh! (.) // Aber ich meine, eure Kinder oder die Nachfolgenden auch schon wieder sich dafür interessieren und dann macht natürlich auch die Arbeit mit den Künstlern ein Mordspaß. Ich habe ja eine ganze Menge abgelegt. Ich mache ja nur noch die vier Serien und eine kleine Hexe Lilly für die Kleinen noch und ein bisschen Grusel noch dazu. Aber sonst habe ich eigentlich nur die Folgen, die ich auch mal, ich will nicht sagen, ich groß gemacht habe, die jedenfalls sehr erfolgreich geworden sind, die habe ich alle noch in meinem Programm.
+<v S00>die habe ich alle noch in meinem Programm.
 
-28
+115
+00:06:52.870 --> 00:06:54.770
+<v S01>Aber das ist auch schon mehr als genug.
+
+116
+00:06:55.630 --> 00:07:00.730
+<v S01>Ja gut, das bringt mich dann zu der Frage, gab es mal so eine Zeit, wo Sie am liebsten alles hingeworfen hätten?
+
+117
+00:07:00.930 --> 00:07:01.010
+<v //S00>//S00: Nee.
+
+118
+00:07:01.110 --> 00:07:01.950
+<v S01>// Weil, gar nicht?
+
+119
 00:07:02.270 --> 00:07:05.250
-<v S01>Aber das ist auch schon mehr als genug. Ja gut, das bringt mich dann zu der Frage, gab es mal so eine Zeit, wo Sie am liebsten alles hingeworfen hätten? //S00: Nee. // Weil, gar nicht? Nicht mal so eine Produktion, wo gar nichts funktioniert hat?
+<v S01>Nicht mal so eine Produktion, wo gar nichts funktioniert hat?
 
-29
+120
+00:07:05.250 --> 00:07:12.890
+<v S00>Nee, also nicht hingeworfen, aber ich ging davon aus, in den 90er Jahren, 2000, als wir vorher...
+
+121
+00:07:12.890 --> 00:07:13.910
+<v //S01>//S01: Und das war eine schwierige Zeit.
+
+122
+00:07:14.250 --> 00:07:14.830
+<v S00>// Das war eine schwierige Zeit.
+
+123
+00:07:14.830 --> 00:07:18.710
+<v S00>Und ich hatte ja, habe ja eben auch noch einen anderen Beruf.
+
+124
+00:07:19.030 --> 00:07:24.030
+<v S00>Aber auf der anderen Seite hatte ich immer eigentlich Lust, schon als junges Mädchen, wollte ich gerne Filme machen.
+
+125
+00:07:24.370 --> 00:07:26.490
+<v S00>Und dann haben wir eine kleine Filmfirma gegründet.
+
+126
+00:07:27.210 --> 00:07:31.670
+<v S00>Und das war aber alles sehr aufwendig, war gar nicht so einfach wie im Tonstudio.
+
+127
+00:07:31.790 --> 00:07:34.330
+<v S00>Da kannst du nicht sagen, du arbeitest Tag und Nacht durch.
+
+128
+00:07:34.550 --> 00:07:36.530
+<v S00>Da brauchst du ja dann Techniker und Leute.
+
+129
+00:07:36.690 --> 00:07:38.070
+<v S00>Und dann muss man, die machen dann acht Stunden.
+
+130
+00:07:38.070 --> 00:07:41.710
+<v S00>Da musst du dann schon immer zwei oder drei nehmen, wenn du durcharbeiten willst.
+
+131
+00:07:42.250 --> 00:07:48.590
+<v S00>Und da war es dann eben so, dass wir eigentlich das Geld gewechselt haben, indem wir dann Werbung machen mussten.
+
+132
+00:07:48.790 --> 00:07:50.730
+<v S00>Das macht aber auf Dauer überhaupt keinen Spaß.
+
+133
+00:07:50.850 --> 00:07:52.550
+<v S00>Ich wollte ja richtig schöne Filme machen.
+
+134
+00:07:52.870 --> 00:07:57.270
+<v S00>Und in der Zwischenzeit, ja, hurra, plötzlich ging das los.
+
+135
+00:07:57.370 --> 00:07:58.450
+<v S00>Man wusste gar nicht, wieso.
+
+136
+00:07:58.750 --> 00:08:00.490
+<v S00>Plötzlich wurde wieder angezogen.
+
+137
+00:08:00.630 --> 00:08:03.090
+<v S00>Da wurden die Kassetten verkauft, CDs verkauft.
+
+138
+00:08:03.250 --> 00:08:07.550
+<v S00>Wir hatten ja bei den drei Fragezeichen beispielsweise die ersten 50 Folgen gar nicht mehr im Programm.
+
+139
+00:08:08.210 --> 00:08:11.650
+<v S00>Und ja, plötzlich kriegte man mit, das läuft wieder.
+
+140
+00:08:12.190 --> 00:08:13.590
+<v S00>Und es ist wieder gefragt.
+
+141
+00:08:14.050 --> 00:08:20.030
+<v S00>Da waren eben dann die zweite Generation, die ältere Generation, die sich erinnerte und sagte,
+
+142
+00:08:20.430 --> 00:08:23.890
+<v S00>Mensch, jetzt haben wir so viel Technisches und weiß echt was nicht alles Tolles.
+
+143
+00:08:24.310 --> 00:08:28.010
+<v S00>Aber was ist eigentlich so in meinem Herzen, was hat mir Freude gemacht?
+
+144
+00:08:28.370 --> 00:08:32.650
+<v S00>Und das ist natürlich so wie für mich bestimmte Bücher, Mistikchen, Fanny Nanny.
+
+145
+00:08:32.770 --> 00:08:35.170
+<v S00>Das waren so meine Kindheitserinnerungen.
+
+146
+00:08:35.170 --> 00:08:38.190
+<v S00>Da gab es ja noch keine, eine Schallplatte hatte ich, eine einzige.
+
+147
+00:08:38.310 --> 00:08:38.790
+<v //S02>//S02: Welche war das?
+
+148
+00:08:38.850 --> 00:08:39.670
+<v S00>// Peter und der Wolf.
+
+149
+00:08:39.990 --> 00:08:40.110
+<v S00>Ah.
+
+150
+00:08:40.110 --> 00:08:43.390
+<v S00>Ja, Peter und der Wolf, die habe ich bestimmt auch tausendmal gehört.
+
+151
+00:08:43.650 --> 00:08:43.830
+<v //S02>//S02: Ja.
+
+152
+00:08:44.310 --> 00:08:45.290
+<v S00>// Mit Matthias Wiemann.
+
+153
+00:08:45.390 --> 00:08:48.030
+<v S00>Ich habe sie ja später nochmal aufgenommen mit Hans Peetsch.
+
+154
+00:08:48.170 --> 00:08:49.390
+<v S00>Aber auch eine schöne Version.
+
+155
+00:08:50.190 --> 00:08:52.830
+<v S00>Ja, also das ist eigentlich der Grund.
+
+156
+00:08:52.950 --> 00:08:54.310
+<v S00>Es macht, es macht Freude.
+
+157
 00:08:54.710 --> 00:08:56.270
-<v S00>Nee, also nicht hingeworfen, aber ich ging davon aus, in den 90er Jahren, 2000, als wir vorher... //S01: Und das war eine schwierige Zeit. // Das war eine schwierige Zeit. Und ich hatte ja, habe ja eben auch noch einen anderen Beruf. Aber auf der anderen Seite hatte ich immer eigentlich Lust, schon als junges Mädchen, wollte ich gerne Filme machen. Und dann haben wir eine kleine Filmfirma gegründet. Und das war aber alles sehr aufwendig, war gar nicht so einfach wie im Tonstudio. Da kannst du nicht sagen, du arbeitest Tag und Nacht durch. Da brauchst du ja dann Techniker und Leute. Und dann muss man, die machen dann acht Stunden. Da musst du dann schon immer zwei oder drei nehmen, wenn du durcharbeiten willst. Und da war es dann eben so, dass wir eigentlich das Geld gewechselt haben, indem wir dann Werbung machen mussten. Das macht aber auf Dauer überhaupt keinen Spaß. Ich wollte ja richtig schöne Filme machen. Und in der Zwischenzeit, ja, hurra, plötzlich ging das los. Man wusste gar nicht, wieso. Plötzlich wurde wieder angezogen. Da wurden die Kassetten verkauft, CDs verkauft. Wir hatten ja bei den drei Fragezeichen beispielsweise die ersten 50 Folgen gar nicht mehr im Programm. Und ja, plötzlich kriegte man mit, das läuft wieder. Und es ist wieder gefragt. Da waren eben dann die zweite Generation, die ältere Generation, die sich erinnerte und sagte, Mensch, jetzt haben wir so viel Technisches und weiß echt was nicht alles Tolles. Aber was ist eigentlich so in meinem Herzen, was hat mir Freude gemacht? Und das ist natürlich so wie für mich bestimmte Bücher, Mistikchen, Fanny Nanny. Das waren so meine Kindheitserinnerungen. Da gab es ja noch keine, eine Schallplatte hatte ich, eine einzige. //S02: Welche war das? // Peter und der Wolf. Ah. Ja, Peter und der Wolf, die habe ich bestimmt auch tausendmal gehört. //S02: Ja. // Mit Matthias Wiemann. Ich habe sie ja später nochmal aufgenommen mit Hans Peetsch. Aber auch eine schöne Version. Ja, also das ist eigentlich der Grund. Es macht, es macht Freude. Ich werde noch gebraucht.
+<v S00>Ich werde noch gebraucht.
 
-30
+158
+00:08:56.510 --> 00:08:57.330
+<v S01>Ja, absolut.
+
+159
 00:08:57.770 --> 00:08:58.810
-<v S01>Ja, absolut. Nicht wegzudenken.
+<v S01>Nicht wegzudenken.
 
-31
+160
+00:08:58.810 --> 00:09:02.490
+<v S00>Ja, ich bin ja auch noch einigermaßen fit und das ist natürlich gut.
+
+161
 00:09:02.610 --> 00:09:03.930
-<v S00>Ja, ich bin ja auch noch einigermaßen fit und das ist natürlich gut. Ich hoffe, das bleibt auch noch ein bisschen.
+<v S00>Ich hoffe, das bleibt auch noch ein bisschen.
 
-32
+162
+00:09:04.230 --> 00:09:07.630
+<v S01>Wo Sie gerade Neuauflagen angesprochen haben mit den drei Fragezeichen.
+
+163
+00:09:07.750 --> 00:09:07.870
+<v //S00>//S00: Ja.
+
+164
+00:09:07.930 --> 00:09:10.290
+<v S01>// Jetzt ist ja Mattel wieder mit den Origins am Start.
+
+165
+00:09:10.530 --> 00:09:10.690
+<v //S00>//S00: Ja.
+
+166
+00:09:10.690 --> 00:09:15.072
+<v S01>// Ja, da wäre doch eine Möglichkeit, die ganzen Sachen nochmal aufzunehmen.
+
+167
 00:09:15.072 --> 00:09:16.190
-<v S01>Wo Sie gerade Neuauflagen angesprochen haben mit den drei Fragezeichen. //S00: Ja. // Jetzt ist ja Mattel wieder mit den Origins am Start. //S00: Ja. // Ja, da wäre doch eine Möglichkeit, die ganzen Sachen nochmal aufzunehmen. (.)
+<v S01>(.)
 
-33
+168
+00:09:16.190 --> 00:09:17.250
+<v S00>Wäre natürlich schön.
+
+169
+00:09:17.450 --> 00:09:17.770
+<v S00>Aber?
+
+170
+00:09:18.230 --> 00:09:22.050
+<v S00>Alles, alles, also das ist ja nicht an mir, sondern es liegt meistens an den Rechten.
+
+171
+00:09:22.270 --> 00:09:26.630
+<v S00>Wir sind auch gerade dabei, wir haben auch jemanden aus der Firma, von Sony, jemanden, der
+
+172
+00:09:26.630 --> 00:09:29.450
+<v S00>jetzt speziell beauftragt ist, mit mir durchzusprechen.
+
+173
+00:09:29.690 --> 00:09:31.830
+<v S00>Was für Sachen haben wir eigentlich noch alles?
+
+174
+00:09:31.890 --> 00:09:34.890
+<v S00>Was haben wir noch alles an Lizenz- und Nicht-Lizenzprodukten?
+
+175
+00:09:34.890 --> 00:09:37.470
+<v S00>Welche könnten wir vielleicht nochmal auf den Markt bringen?
+
+176
+00:09:37.710 --> 00:09:39.290
+<v S00>Mit wem kann man verhandeln?
+
+177
+00:09:39.450 --> 00:09:44.250
+<v S00>Da sind wir schwer dabei und auch beim Masters of the Universe ist noch nicht das letzte
+
+178
 00:09:44.250 --> 00:09:47.590
-<v S00>Wäre natürlich schön. Aber? Alles, alles, also das ist ja nicht an mir, sondern es liegt meistens an den Rechten. Wir sind auch gerade dabei, wir haben auch jemanden aus der Firma, von Sony, jemanden, der jetzt speziell beauftragt ist, mit mir durchzusprechen. Was für Sachen haben wir eigentlich noch alles? Was haben wir noch alles an Lizenz- und Nicht-Lizenzprodukten? Welche könnten wir vielleicht nochmal auf den Markt bringen? Mit wem kann man verhandeln? Da sind wir schwer dabei und auch beim Masters of the Universe ist noch nicht das letzte Wort gesprochen, was nicht doch auch klappen könnte.
+<v S00>Wort gesprochen, was nicht doch auch klappen könnte.
 
-34
+179
 00:09:47.810 --> 00:09:51.530
 <v S01>Also gibt es vielleicht die Chance, dass es das irgendwann mal auf Schallplatte gäbe?
 
-35
-00:09:57.190 --> 00:09:58.550
-<v S00>Ja, ich sehe hier gerade Kung-Fu, wer hat das mitgebracht? Ich hoffe, jeder kennt die. Sind die nicht toll?
+180
+00:09:51.530 --> 00:09:53.510
+<v S00>Ja, ich sehe hier gerade Kung-Fu, wer hat das mitgebracht?
 
-36
+181
+00:09:53.690 --> 00:09:56.750
+<v S00>Ich hoffe, jeder kennt die.
+
+182
+00:09:57.190 --> 00:09:58.550
+<v S00>Sind die nicht toll?
+
+183
 00:09:58.790 --> 00:09:59.590
 <v S01>Ja, großartig.
 
-37
+184
+00:09:59.590 --> 00:10:04.590
+<v S00>Und das war, das war ganz spannend, da war ich in München mit meinem Mann bei einer
+
+185
+00:10:04.590 --> 00:10:11.500
+<v S00>Freundin und las in der Bild-Zeitung, glaube ich, Horst Frank verliebt in Brigitte Kollecker
+
+186
+00:10:11.500 --> 00:10:17.180
+<v S00>und süße Bilder auch von ihr, weil er eine bezaubernd hübsche Person und da habe ich
+
+187
+00:10:17.180 --> 00:10:23.020
+<v S00>gesagt, das ist die Gelegenheit, Horst kriege ich vielleicht so leicht nicht allein, aber wenn
+
+188
+00:10:23.020 --> 00:10:24.180
+<v S00>wir die im Doppelpunkt haben.
+
+189
+00:10:24.400 --> 00:10:30.000
+<v S00>Ah, über die Hintertür, nein, ja, ja, ja, ja, genau, genau, ja, und dann, und bei
+
+190
+00:10:30.040 --> 00:10:33.400
+<v S00>der Gelegenheit habe ich dann, und dann haben wir das sogar in München aufgenommen,
+
+191
+00:10:33.580 --> 00:10:34.520
+<v S00>relativ spontan.
+
+192
+00:10:34.740 --> 00:10:36.240
+<v S00>Ach, gar nicht, gar nicht in Ihrem Studien?
+
+193
+00:10:36.360 --> 00:10:40.260
+<v S00>Nein, nein, das haben wir aber dann in unserem Studium dann nachbearbeitet.
+
+194
+00:10:40.540 --> 00:10:40.660
+<v S00>Ja, ja, ja.
+
+195
 00:10:40.680 --> 00:10:43.120
-<v S00>Und das war, das war ganz spannend, da war ich in München mit meinem Mann bei einer Freundin und las in der Bild-Zeitung, glaube ich, Horst Frank verliebt in Brigitte Kollecker und süße Bilder auch von ihr, weil er eine bezaubernd hübsche Person und da habe ich gesagt, das ist die Gelegenheit, Horst kriege ich vielleicht so leicht nicht allein, aber wenn wir die im Doppelpunkt haben. Ah, über die Hintertür, nein, ja, ja, ja, ja, genau, genau, ja, und dann, und bei der Gelegenheit habe ich dann, und dann haben wir das sogar in München aufgenommen, relativ spontan. Ach, gar nicht, gar nicht in Ihrem Studien? Nein, nein, das haben wir aber dann in unserem Studium dann nachbearbeitet. Ja, ja, ja. Ja, ich habe gerade gesehen.
+<v S00>Ja, ich habe gerade gesehen.
 
-38
+196
+00:10:43.500 --> 00:10:44.340
+<v S01>Ja, und zwar?
+
+197
 00:10:44.340 --> 00:10:45.856
-<v S01>Ja, und zwar? (..)
+<v S01>(..)
 
-39
+198
 00:10:45.856 --> 00:10:46.610
 <v S00>Ich muss zum Zug.
 
-40
-00:10:51.250 --> 00:10:52.050
-<v //S00>Ah, okay, dann kommen wir langsam, dann kommen wir langsam zu Ende, aber ich lasse es mir //S00: natürlich nicht nehmen.//
+199
+00:10:46.850 --> 00:10:51.250
+<v S01>Ah, okay, dann kommen wir langsam, dann kommen wir langsam zu Ende, aber ich lasse es mir
 
-41
+200
+00:10:51.250 --> 00:10:52.050
+<v //S00>//S00: natürlich nicht nehmen.//
+
+201
 00:10:52.050 --> 00:10:53.390
 <v S00>Aber ich komme wieder, es war so nett.
 
-42
-00:10:58.430 --> 00:11:00.990
-<v S01>Ich lasse es mir natürlich nicht nehmen, diese beiden Platten von Ihnen bitte noch signieren zu lassen. //S00: Genau. // Damit die einen würdigen Platz in meinem Plattenregal finden.
+202
+00:10:53.970 --> 00:10:57.790
+<v S01>Ich lasse es mir natürlich nicht nehmen, diese beiden Platten von Ihnen bitte noch signieren
 
-43
+203
+00:10:57.790 --> 00:10:58.130
+<v S01>zu lassen.
+
+204
+00:10:58.290 --> 00:10:58.430
+<v //S00>//S00: Genau.
+
+205
+00:10:58.430 --> 00:11:00.990
+<v S01>// Damit die einen würdigen Platz in meinem Plattenregal finden.
+
+206
 00:11:00.990 --> 00:11:02.110
 <v S00>Mit deinem Namen, wie heißt die?
 
-44
+207
 00:11:02.270 --> 00:11:03.330
 <v S01>Ähm, ähm, ähm...
 
-45
+208
 00:11:03.330 --> 00:11:04.410
 <v S00>Oder nur Heike-Diene-Fabrik?
 
-46
-00:11:08.480 --> 00:11:09.480
-<v S01>Ja, einfach Heike-Diene-Karting drauf. Das ist super. Das mache ich doch gerne. Das macht...
+209
+00:11:04.450 --> 00:11:06.016
+<v S01>Ja, einfach Heike-Diene-Karting drauf.
 
-47
+210
+00:11:06.848 --> 00:11:07.140
+<v S01>Das ist super.
+
+211
+00:11:07.140 --> 00:11:08.160
+<v S01>Das mache ich doch gerne.
+
+212
+00:11:08.480 --> 00:11:09.480
+<v S01>Das macht...
+
+213
 00:11:09.480 --> 00:11:12.960
 <v S00>Also, ich liebe die, also, die kann ich auch noch auswendig.
 
-48
-00:11:14.784 --> 00:11:15.904
-<v S01>Und natürlich den Kabaden. (.)
+214
+00:11:13.160 --> 00:11:14.784
+<v S01>Und natürlich den Kabaden.
 
-49
+215
+00:11:14.784 --> 00:11:15.904
+<v S01>(.)
+
+216
 00:11:15.904 --> 00:11:17.280
 <v S00>Der wird mit Rot unterschrieben.
 
-50
+217
+00:11:17.440 --> 00:11:19.620
+<v S01>Ja, Rot auf Blau, das ist doch super.
+
+218
 00:11:19.620 --> 00:11:21.792
-<v S01>Ja, Rot auf Blau, das ist doch super. (..)
+<v S01>(..)
 
-51
+219
+00:11:21.792 --> 00:11:26.700
+<v S00>Ja, ich komme ja aus Hamburg und habe jetzt fünfeinhalb Stunden Zugfahrt.
+
+220
+00:11:27.240 --> 00:11:27.640
+<v S00>Zugfahrt.
+
+221
+00:11:27.640 --> 00:11:27.920
+<v //S01>//S01: Oh mein Gott.
+
+222
+00:11:28.100 --> 00:11:28.420
+<v //S01>Oh mein Gott.
+
+223
+00:11:28.680 --> 00:11:28.780
+<v //S01>Ja.
+
+224
+00:11:28.900 --> 00:11:33.340
+<v S00>// Aber das habe ich gern gemacht, habe ich gern gemacht, was, wie gesagt, hat mir richtig
+
+225
+00:11:33.340 --> 00:11:34.260
+<v S00>doll Freude gemacht.
+
+226
+00:11:34.500 --> 00:11:35.660
+<v S00>Für DSD.
+
+227
 00:11:35.660 --> 00:11:37.200
-<v S00>Ja, ich komme ja aus Hamburg und habe jetzt fünfeinhalb Stunden Zugfahrt. Zugfahrt. //S01: Oh mein Gott. Oh mein Gott. Ja. // Aber das habe ich gern gemacht, habe ich gern gemacht, was, wie gesagt, hat mir richtig doll Freude gemacht. Für DSD. (..)
+<v S00>(..)
 
-52
+228
+00:11:37.200 --> 00:11:38.000
+<v S01>Für DSD.
+
+229
+00:11:38.220 --> 00:11:38.540
+<v S01>Groß?
+
+230
+00:11:38.820 --> 00:11:40.340
+<v S01>Ja, ja, alles groß, große Lettern.
+
+231
+00:11:40.600 --> 00:11:44.520
+<v S01>Dann haben wir hier noch die Autogrammstunde, die private sozusagen.
+
+232
+00:11:44.880 --> 00:11:46.280
+<v S01>Die Frau Körting geht hier zum Zug.
+
+233
+00:11:46.360 --> 00:11:48.680
+<v S01>Ich danke vielmals für dieses kleine Gespräch.
+
+234
+00:11:48.760 --> 00:11:52.160
+<v S01>Das bedeutet mir wirklich sehr viel, dass Sie sich dafür Zeit genommen haben.
+
+235
+00:11:52.660 --> 00:11:56.560
+<v S01>Wünsche Ihnen eine gesunde und gute Rückfahrt nach Hamburg.
+
+236
+00:11:56.840 --> 00:11:56.960
+<v S01>Ja.
+
+237
+00:11:57.140 --> 00:11:59.020
+<v S01>Ist ja nicht so gerade um die Ecke.
+
+238
+00:11:59.320 --> 00:11:59.440
+<v S01>Nee.
+
+239
 00:11:59.620 --> 00:12:01.740
-<v S01>Für DSD. Groß? Ja, ja, alles groß, große Lettern. Dann haben wir hier noch die Autogrammstunde, die private sozusagen. Die Frau Körting geht hier zum Zug. Ich danke vielmals für dieses kleine Gespräch. Das bedeutet mir wirklich sehr viel, dass Sie sich dafür Zeit genommen haben. Wünsche Ihnen eine gesunde und gute Rückfahrt nach Hamburg. Ja. Ist ja nicht so gerade um die Ecke. Nee. Und dann hoffe ich, dass wir uns vielleicht irgendwann mal wiedersehen.
+<v S01>Und dann hoffe ich, dass wir uns vielleicht irgendwann mal wiedersehen.
 
-53
+240
 00:12:01.800 --> 00:12:02.600
 <v S00>Das wäre doch toll.
 
-54
+241
 00:12:02.820 --> 00:12:02.900
 <v S01>Ja.
 
-55
-00:12:04.660 --> 00:12:06.160
-<v S00>Ich freue mich. //S01: Vielen lieben Dank. // Ganz, ganz große Freude.
+242
+00:12:03.060 --> 00:12:03.820
+<v S00>Ich freue mich.
 
-56
+243
+00:12:04.020 --> 00:12:04.420
+<v //S01>//S01: Vielen lieben Dank.
+
+244
+00:12:04.660 --> 00:12:06.160
+<v S00>// Ganz, ganz große Freude.
+
+245
+00:12:06.460 --> 00:12:08.240
+<v S01>Oh, wir haben sogar Puppetum gemacht.
+
+246
+00:12:08.700 --> 00:12:13.220
+<v S01>So, zu viel Internet ist aber ungesund und deswegen könnt ihr jetzt was genau richtig abschalten.
+
+247
+00:12:13.560 --> 00:12:14.960
+<v S01>Abschalten, abschalten, abschalten, abschalten, abschalten.
+
+248
+00:12:14.960 --> 00:12:17.141
+<v S01>(..)
+
+249
 00:12:17.141 --> 00:12:15.168
-<v S01>Oh, wir haben sogar Puppetum gemacht. So, zu viel Internet ist aber ungesund und deswegen könnt ihr jetzt was genau richtig abschalten. Abschalten, abschalten, abschalten, abschalten, abschalten. (..) Ja.
+<v S01>Ja.
 


### PR DESCRIPTION
## Problem
The `pytest` workflow is currently **red on `main`** (and therefore on every PR). The failing test is `tests/test_utils.py::test_html_to_webvtt`.

## Root cause
Commit `338263d` *"Fix WebVTT cue splitting"* intentionally changed `html_to_webvtt` so that **each timestamp anchor becomes its own cue** with correct per-segment start/end times, and added inline assertions in `test_utils.py` that require this splitting. Those inline assertions pass.

However, the golden fixture `tests/data/interview.vtt` was **not regenerated** in that commit (it was last touched in `ba1c0b0`, before the fix). It still contains the old paragraph-merged cues with incorrect timestamps — e.g. a 1.2‑second cue holding an entire paragraph. So the final comparison against that file fails.

## Fix
Regenerate `tests/data/interview.vtt` from the current, corrected `html_to_webvtt` output. **No source code is changed** — only the stale test fixture is updated to match the behaviour the inline assertions already lock in.

## Verification
`pytest tests/ -q` → **17 passed** (previously 1 failed, 16 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)