### PR TITLE
Fix crash when the remembered AI model is no longer available

### DIFF
--- a/noScribe/main.py
+++ b/noScribe/main.py
@@ -1100,7 +1100,7 @@ class App(ctk.CTk):
         if last_whisper_model in self.whisper_models:
             self.option_menu_whisper_model.set(last_whisper_model)
         elif len(self.whisper_models) > 0:
-            self.option_menu_whisper_model.set(next(self.whisper_models.keys()))
+            self.option_menu_whisper_model.set(next(iter(self.whisper_models)))
 
         # Mark pauses
         self.label_pause = ctk.CTkLabel(self.frame_options, text=t('label_pause'))
@@ -3307,7 +3307,7 @@ def run_cli_mode(args):
             if 'precise' in app.whisper_models:
                 args.model = 'precise'
             elif app.whisper_models:
-                args.model = app.whisper_models.keys()[0]
+                args.model = next(iter(app.whisper_models))
             else:
                 print("Error: No Whisper models found.")
                 return 1


### PR DESCRIPTION
## Problem

`dict.keys()` returns a view, which is neither an iterator nor a sequence. Both places that fall back to "the first available model" treat it as one, so they raise a `TypeError`:

**1. GUI — the app does not start at all**

```python
last_whisper_model = get_config('last_whisper_model', 'precise')
if last_whisper_model in self.whisper_models:
    self.option_menu_whisper_model.set(last_whisper_model)
elif len(self.whisper_models) > 0:
    self.option_menu_whisper_model.set(next(self.whisper_models.keys()))
    # TypeError: 'dict_keys' object is not an iterator
```

This runs whenever `last_whisper_model` from `config.yml` is not among the installed models — e.g. after a model folder was renamed, moved or removed, or when the config was written by an installation that had a model this one does not have. Instead of falling back to an available model, noScribe fails to start (the exception surfaces as a bare `'dict_keys' object is not an iterator` line and the window never appears).

**2. CLI — same bug, different message**

```python
elif app.whisper_models:
    args.model = app.whisper_models.keys()[0]
    # TypeError: 'dict_keys' object is not subscriptable
```

Hit in `--no-gui` mode when `--model` is omitted and no model named `precise` is installed.

## Fix

Both now use `next(iter(...))`, which yields the first key in insertion order — the same model the dropdown lists first (`values=list(self.whisper_models.keys())`).

## Reproducing / testing

With a `config.yml` containing a `last_whisper_model` that is not installed (in my case a model dir that is skipped because it has no `model.bin`):

- before: the app exits during startup with `'dict_keys' object is not an iterator`
- after: the app starts normally and preselects the first available model

Verified by launching noScribe from source with the same unchanged config before and after the change (macOS / Apple Silicon), plus the isolated behaviour of both expressions. `pytest` passes (17 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)