### PR TITLE
Render the transcript-header options consistently

### DIFF
--- a/noScribe/main.py
+++ b/noScribe/main.py
@@ -207,6 +207,17 @@ _CUDA_ERROR_KEYWORDS = (
     'hip error',
 )
 
+def pause_label(pause) -> str:
+    """Map the pause-threshold option index back to its display label.
+
+    Called at display time, not at import time, so the label follows the
+    UI language.
+    """
+    opts = [t('pause_none'), '1sec+', '2sec+', '3sec+']
+    if isinstance(pause, int) and 0 <= pause < len(opts):
+        return opts[pause]
+    return str(pause)
+
 def _is_cuda_error_message(message: str) -> bool:
     if not message:
         return False
@@ -430,9 +441,7 @@ class TranscriptionJob:
 
         # Pause threshold (map int index back to label)
         try:
-            pause_opts = ['none', '1sec+', '2sec+', '3sec+']
-            pause_disp = pause_opts[self.pause] if isinstance(self.pause, int) and 0 <= self.pause < len(pause_opts) else str(self.pause)
-            lines.append(f"{t('label_pause')} {pause_disp}")
+            lines.append(f"{t('label_pause')} {pause_label(self.pause)}")
         except Exception:
             pass
 
@@ -2361,10 +2370,15 @@ class App(ctk.CTk):
                 option_info += f'{t("label_stop")} {utils.ms_to_str(job.stop)} | '.replace(':', '꞉')
             option_info += f'{t("label_language")} {job.language_name} ({languages[job.language_name]}) | '
             option_info += f'{t("label_speaker")} {job.speaker_detection} | '
-            option_info += f'{t("label_overlapping")} {job.overlapping} | '
-            option_info += f'{t("label_timestamps")} {job.timestamps} | '
-            option_info += f'{t("label_disfluencies")} {job.disfluencies} | '
-            option_info += f'{t("label_pause")} {job.pause}'
+            # Render the on/off options as localized yes/no and the pause
+            # threshold as its label, so this header -- which ends up in the
+            # transcript itself -- never mixes True/False with a raw 0. The job
+            # tooltip shows the same values, but as ✓/✗ where space is tight.
+            yes, no = t('opt_yes'), t('opt_no')
+            option_info += f'{t("label_overlapping")} {yes if job.overlapping else no} | '
+            option_info += f'{t("label_timestamps")} {yes if job.timestamps else no} | '
+            option_info += f'{t("label_disfluencies")} {yes if job.disfluencies else no} | '
+            option_info += f'{t("label_pause")} {pause_label(job.pause)}'
 
             # Create log file
             if not os.path.exists(f'{config_dir}/log'):

--- a/noScribe/main.py
+++ b/noScribe/main.py
@@ -207,15 +207,24 @@ _CUDA_ERROR_KEYWORDS = (
     'hip error',
 )
 
+PAUSE_OPTIONS = ['none', '1sec+', '2sec+', '3sec+']
+
+
 def pause_label(pause) -> str:
     """Map the pause-threshold option index back to its display label.
 
-    Called at display time, not at import time, so the label follows the
-    UI language.
+    Deliberately not translated. These are the identifiers the user picks in
+    the dropdown and passes to --pause, and they are what gets stored in the
+    config; a transcript naming the setting something the app never showed
+    would be worse than an English word in a German header. The yes/no values
+    next to it are translated because they render a boolean, which has no
+    user-facing token at all.
     """
-    opts = [t('pause_none'), '1sec+', '2sec+', '3sec+']
-    if isinstance(pause, int) and 0 <= pause < len(opts):
-        return opts[pause]
+    # bool is a subclass of int, so it would index the list instead of taking
+    # the fallback below.
+    if isinstance(pause, int) and not isinstance(pause, bool) \
+            and 0 <= pause < len(PAUSE_OPTIONS):
+        return PAUSE_OPTIONS[pause]
     return str(pause)
 
 def _is_cuda_error_message(message: str) -> bool:
@@ -430,11 +439,11 @@ class TranscriptionJob:
         except Exception:
             pass
 
-        # Model (display basename if a path)
+        # Model. whisper_model is a transcription.WhisperModel, so os.path
+        # functions raise TypeError on it -- which the except below swallowed,
+        # dropping this line from every tooltip.
         try:
-            model_disp = os.path.basename(self.whisper_model) if self.whisper_model else ''
-            if not model_disp:
-                model_disp = str(self.whisper_model)
+            model_disp = getattr(self.whisper_model, 'name', None) or str(self.whisper_model or '')
             lines.append(f"{t('label_whisper_model')} {model_disp}")
         except Exception:
             pass
@@ -614,9 +623,8 @@ def create_transcription_job(audio_file=None, transcript_file=None, start_time=N
     # Pause setting
     if pause is not None:
         if isinstance(pause, str):
-            pause_options = ['none', '1sec+', '2sec+', '3sec+']
-            if pause in pause_options:
-                job.pause = pause_options.index(pause)
+            if pause in PAUSE_OPTIONS:
+                job.pause = PAUSE_OPTIONS.index(pause)
             else:
                 job.pause = 1  # default to '1sec+'
         else:
@@ -733,7 +741,7 @@ Examples:
                        help='Include disfluencies (uh, um, etc.) in transcript')
     parser.add_argument('--no-disfluencies', action='store_false', dest='disfluencies', default=None,
                        help='Exclude disfluencies from transcript')
-    parser.add_argument('--pause', choices=['none', '1sec+', '2sec+', '3sec+'], default=None,
+    parser.add_argument('--pause', choices=PAUSE_OPTIONS, default=None,
                        help='Mark pauses in transcript')
     
     return parser.parse_args()
@@ -1124,7 +1132,7 @@ class App(ctk.CTk):
         self.label_pause = ctk.CTkLabel(self.frame_options, text=t('label_pause'))
         self.label_pause.grid(column=0, row=4, sticky='w', pady=5)
 
-        self.option_menu_pause = ctk.CTkOptionMenu(self.frame_options, width=100, values=['none', '1sec+', '2sec+', '3sec+'])
+        self.option_menu_pause = ctk.CTkOptionMenu(self.frame_options, width=100, values=PAUSE_OPTIONS)
         self.option_menu_pause.grid(column=1, row=4, sticky='e', pady=5)
         self.option_menu_pause.set(get_config('last_pause', '1sec+'))
 

--- a/tests/test_pause_label.py
+++ b/tests/test_pause_label.py
@@ -1,0 +1,22 @@
+"""The pause threshold is stored as an option index and rendered in two places
+(transcript header and job tooltip). Both go through pause_label, so the
+index -> label mapping and its fallback are pinned here.
+"""
+import pytest
+
+pytest.importorskip("tkinter")  # noScribe.main pulls in the GUI stack
+
+import noScribe.main as m
+
+
+def test_known_indices_map_to_their_label():
+    assert m.pause_label(1) == '1sec+'
+    assert m.pause_label(3) == '3sec+'
+
+
+def test_out_of_range_and_non_int_fall_back_to_str():
+    # Guards against an IndexError in the transcript header if the stored
+    # config value ever drifts out of the option list.
+    assert m.pause_label(99) == '99'
+    assert m.pause_label('2sec+') == '2sec+'
+    assert m.pause_label(None) == 'None'

--- a/tests/test_pause_label.py
+++ b/tests/test_pause_label.py
@@ -2,16 +2,20 @@
 (transcript header and job tooltip). Both go through pause_label, so the
 index -> label mapping and its fallback are pinned here.
 """
-import pytest
-
-pytest.importorskip("tkinter")  # noScribe.main pulls in the GUI stack
-
 import noScribe.main as m
 
 
-def test_known_indices_map_to_their_label():
-    assert m.pause_label(1) == '1sec+'
-    assert m.pause_label(3) == '3sec+'
+def test_every_option_maps_to_its_own_label():
+    # The labels are the identifiers the user picks in the dropdown and passes
+    # to --pause, so they must survive rendering unchanged and in order.
+    assert [m.pause_label(i) for i in range(len(m.PAUSE_OPTIONS))] == m.PAUSE_OPTIONS
+
+
+def test_a_rendered_label_maps_back_to_its_index():
+    """The header shows what the dropdown offers, so the two have to agree --
+    which is why they share one list instead of keeping a copy each."""
+    for i, label in enumerate(m.PAUSE_OPTIONS):
+        assert m.PAUSE_OPTIONS.index(m.pause_label(i)) == i
 
 
 def test_out_of_range_and_non_int_fall_back_to_str():
@@ -20,3 +24,7 @@ def test_out_of_range_and_non_int_fall_back_to_str():
     assert m.pause_label(99) == '99'
     assert m.pause_label('2sec+') == '2sec+'
     assert m.pause_label(None) == 'None'
+    # bool is a subclass of int; without the explicit check True would index
+    # the list and render as '1sec+'.
+    assert m.pause_label(True) == 'True'
+    assert m.pause_label(False) == 'False'

--- a/trans/noScribe.de.yml
+++ b/trans/noScribe.de.yml
@@ -45,6 +45,9 @@ de:
   label_pause: 'Pausen markieren:'
   label_timestamps: 'Zeitmarken:'
   label_disfluencies: 'Füllworte:'
+  opt_yes: 'Ja'
+  opt_no: 'Nein'
+  pause_none: 'keine'
 
   start_button: Start
   start_queue: 'Auftrag jetzt starten'

--- a/trans/noScribe.de.yml
+++ b/trans/noScribe.de.yml
@@ -47,7 +47,6 @@ de:
   label_disfluencies: 'Füllworte:'
   opt_yes: 'Ja'
   opt_no: 'Nein'
-  pause_none: 'keine'
 
   start_button: Start
   start_queue: 'Auftrag jetzt starten'

--- a/trans/noScribe.en.yml
+++ b/trans/noScribe.en.yml
@@ -46,6 +46,9 @@ en:
   label_pause: 'Mark pause:'
   label_timestamps: 'Timestamps:'
   label_disfluencies: 'Disfluencies:'
+  opt_yes: 'Yes'
+  opt_no: 'No'
+  pause_none: 'none'
   
   start_button: Start 
   start_queue: 'Start job now'

--- a/trans/noScribe.en.yml
+++ b/trans/noScribe.en.yml
@@ -48,7 +48,6 @@ en:
   label_disfluencies: 'Disfluencies:'
   opt_yes: 'Yes'
   opt_no: 'No'
-  pause_none: 'none'
   
   start_button: Start 
   start_queue: 'Start job now'

--- a/trans/noScribe.es.yml
+++ b/trans/noScribe.es.yml
@@ -44,6 +44,9 @@ es:
   label_pause: 'Marca pausas:'
   label_timestamps: 'Timestamps:'
   label_disfluencies: 'Disfluencias:'
+  opt_yes: 'Sí'
+  opt_no: 'No'
+  pause_none: 'ninguna'
   
   start_button: Iniciar
   start_queue: 'Iniciar trabajo ahora'

--- a/trans/noScribe.es.yml
+++ b/trans/noScribe.es.yml
@@ -46,7 +46,6 @@ es:
   label_disfluencies: 'Disfluencias:'
   opt_yes: 'Sí'
   opt_no: 'No'
-  pause_none: 'ninguna'
   
   start_button: Iniciar
   start_queue: 'Iniciar trabajo ahora'

--- a/trans/noScribe.fr.yml
+++ b/trans/noScribe.fr.yml
@@ -44,6 +44,9 @@ fr:
   label_pause: 'Marquer les pauses :'
   label_timestamps: 'Horodatage :'
   label_disfluencies: 'Mots de remplissage :'
+  opt_yes: 'Oui'
+  opt_no: 'Non'
+  pause_none: 'aucune'
   
   start_button: "Démarrer"
   start_queue: 'Démarrer la tâche maintenant'

--- a/trans/noScribe.fr.yml
+++ b/trans/noScribe.fr.yml
@@ -46,7 +46,6 @@ fr:
   label_disfluencies: 'Mots de remplissage :'
   opt_yes: 'Oui'
   opt_no: 'Non'
-  pause_none: 'aucune'
   
   start_button: "Démarrer"
   start_queue: 'Démarrer la tâche maintenant'

--- a/trans/noScribe.it.yml
+++ b/trans/noScribe.it.yml
@@ -44,6 +44,9 @@ it:
   label_pause: 'Segna le pause:'
   label_timestamps: 'Timestamps:'
   label_disfluencies: 'Disfluenze:'
+  opt_yes: 'Sì'
+  opt_no: 'No'
+  pause_none: 'nessuna'
   
   start_button: Avvia
   start_queue: 'Avvia attività ora'

--- a/trans/noScribe.it.yml
+++ b/trans/noScribe.it.yml
@@ -46,7 +46,6 @@ it:
   label_disfluencies: 'Disfluenze:'
   opt_yes: 'Sì'
   opt_no: 'No'
-  pause_none: 'nessuna'
   
   start_button: Avvia
   start_queue: 'Avvia attività ora'

--- a/trans/noScribe.ja.yml
+++ b/trans/noScribe.ja.yml
@@ -45,6 +45,9 @@ ja:
   label_pause: 'マークはポーズをとる：'
   label_timestamps: 'タイムスタンプ：'
   label_disfluencies: 'フィラー：'
+  opt_yes: 'はい'
+  opt_no: 'いいえ'
+  pause_none: 'なし'
 
   start_button: 開始
   start_queue: '今すぐジョブを開始'

--- a/trans/noScribe.ja.yml
+++ b/trans/noScribe.ja.yml
@@ -47,7 +47,6 @@ ja:
   label_disfluencies: 'フィラー：'
   opt_yes: 'はい'
   opt_no: 'いいえ'
-  pause_none: 'なし'
 
   start_button: 開始
   start_queue: '今すぐジョブを開始'

--- a/trans/noScribe.pt.yml
+++ b/trans/noScribe.pt.yml
@@ -45,6 +45,9 @@ pt:
   label_pause: 'Marcar pausas:'
   label_timestamps: 'Registos temporais:'
   label_disfluencies: 'Disfluências:'
+  opt_yes: 'Sim'
+  opt_no: 'Não'
+  pause_none: 'nenhuma'
   
   start_button: Iniciar
   start_queue: 'Iniciar tarefa agora'

--- a/trans/noScribe.pt.yml
+++ b/trans/noScribe.pt.yml
@@ -47,7 +47,6 @@ pt:
   label_disfluencies: 'Disfluências:'
   opt_yes: 'Sim'
   opt_no: 'Não'
-  pause_none: 'nenhuma'
   
   start_button: Iniciar
   start_queue: 'Iniciar tarefa agora'

--- a/trans/noScribe.ru.yml
+++ b/trans/noScribe.ru.yml
@@ -45,6 +45,9 @@ ru:
   label_pause: 'Отметьте паузы:'
   label_timestamps: 'Временные метки:'
   label_disfluencies: 'Паразитные слова:'
+  opt_yes: 'Да'
+  opt_no: 'Нет'
+  pause_none: 'нет'
   
   start_button: Старт
   start_queue: 'Запустить задание сейчас'

--- a/trans/noScribe.ru.yml
+++ b/trans/noScribe.ru.yml
@@ -47,7 +47,6 @@ ru:
   label_disfluencies: 'Паразитные слова:'
   opt_yes: 'Да'
   opt_no: 'Нет'
-  pause_none: 'нет'
   
   start_button: Старт
   start_queue: 'Запустить задание сейчас'

--- a/trans/noScribe.zh-CN.yml
+++ b/trans/noScribe.zh-CN.yml
@@ -44,6 +44,9 @@ zh-CN: &defaults
   label_pause: '标记停顿：'
   label_timestamps: '时间戳：'
   label_disfluencies: '语言停顿：'
+  opt_yes: '是'
+  opt_no: '否'
+  pause_none: '无'
   
   start_button: 开始 
   start_queue: '立即开始任务'

--- a/trans/noScribe.zh-CN.yml
+++ b/trans/noScribe.zh-CN.yml
@@ -46,7 +46,6 @@ zh-CN: &defaults
   label_disfluencies: '语言停顿：'
   opt_yes: '是'
   opt_no: '否'
-  pause_none: '无'
   
   start_button: 开始 
   start_queue: '立即开始任务'


### PR DESCRIPTION
The options line in the document / VTT header mixed value styles: the on/off
options rendered as Python `True`/`False` while the pause threshold rendered as a
raw index (`0`). This renders the on/off options as a localized yes/no and the
pause as its label, so the line reads e.g.:

```
... | Overlapping speech: No | Timestamps: No | Disfluencies: Yes | Mark pause: none
```

Changes:

- Add `opt_yes` / `opt_no` to all 9 locales and render the header through them.
- Map the pause index back to its label in one place, `pause_label()`, shared
  with the job tooltip that renders the same value. (The tooltip keeps its ✓/✗
  for the on/off options, where space is tight; the header, which ends up in the
  transcript itself, spells them out.)

One visible change beyond the header text: the job tooltip's model line, which
had been silently dropped (`os.path.basename` raised a `TypeError` on the
`WhisperModel` object and the surrounding `except` swallowed it), now shows the
model name. The pause dropdown itself still uses
its internal tokens (`none`/`1sec+`/…) since those double as the stored config
and CLI values.

The German de-gendering that was originally part of this PR now lives in #331,
so this one is purely technical.

---

**Overlaps with #323.** Both PRs touch the `option_info` block in `noScribe/main.py`: #323 inserts a speaker-names line after `label_speaker`, this one replaces the four lines below it. Whichever merges second needs a one-line rebase — keep both sides, speaker names first:

```python
option_info += f'{t("label_speaker")} {job.speaker_detection} | '
if job.speaker_names:
    option_info += f'{t("label_speaker_names")} {", ".join(job.speaker_names)} | '
yes, no = t('opt_yes'), t('opt_no')
option_info += f'{t("label_overlapping")} {yes if job.overlapping else no} | '
option_info += f'{t("label_timestamps")} {yes if job.timestamps else no} | '
option_info += f'{t("label_disfluencies")} {yes if job.disfluencies else no} | '
option_info += f'{t("label_pause")} {pause_label(job.pause)}'
```

I rebased locally to confirm this is the whole conflict and that the suite passes afterwards. No conflict with #326, #327, #328, #330 or #331.

