### PR TITLE
Raise the macOS arm64 torch stack to torch 2.13 / torchaudio 2.11 / torchcodec 0.15

### DIFF
--- a/environments/requirements_macOS_arm64.txt
+++ b/environments/requirements_macOS_arm64.txt
@@ -1,7 +1,10 @@
 # Install with `pip install -r requirements_macOS_arm64.txt`
-# torch==2.8 # pyannote 4 is currently not compatible with torch 2.9; torch version is set by torchaudio
-torchaudio==2.8
-torchcodec==0.7.0
+# Tested stack (2026-07, macOS arm64): torch 2.13 / torchaudio 2.11 / torchcodec 0.15
+# run pyannote 4 diarization with identical output and speed as torch 2.8, and
+# torchcodec 0.15 loads against Homebrew FFmpeg 8 (0.7 supported FFmpeg 4-7 only).
+torch==2.13
+torchaudio==2.11
+torchcodec==0.15.0
 av
 AdvancedHTMLParser
 appdirs


### PR DESCRIPTION
## What

Bump the pinned torch stack in `environments/requirements_macOS_arm64.txt` to
torch 2.13 / torchaudio 2.11 / torchcodec 0.15. The old comment ("pyannote 4 is
currently not compatible with torch 2.9") no longer holds.

## Verified (M1 Max, macOS)

- pyannote 4.0.7 diarization on torch 2.13 + MPS: **identical segments and speakers** on a 4-min benchmark vs. torch 2.8, same speed warm (~10–15 s; the very first run is slower once while MPS kernels compile).
- The unchanged `torchaudio.load` path still works on torchaudio 2.11 (verified with a real spawn-child diarization run — 242 segments, 4 speakers).
- torchcodec 0.15 loads against Homebrew FFmpeg 8, so the cosmetic "libtorchcodec could not be loaded" startup warning disappears (0.7 supported FFmpeg 4–7 only).
- `torchaudio.functional.forced_align`/`merge_tokens` still exist in 2.11, no longer deprecated, and return bit-identical alignments across 43 recorded test cases (relevant for anyone building on them).

## Scope

- Only the macOS arm64 requirements are touched; Windows/Linux pins are unchanged because I could not test those platforms.
- The lazy-import commit that was originally part of this PR is now #330 — it is not macOS-specific and stands on its own. Merging it as well also removes the objc duplicate-class warnings that appear on macOS when PyAV's bundled FFmpeg is loaded next to torchcodec's system FFmpeg 8.
- Independent of #326 (no overlapping files; either can merge first — together they make noScribe's own code fully torchaudio-free).

🤖 Generated with [Claude Code](https://claude.com/claude-code)