### PR TITLE
Load noScribe.main lazily so worker subprocesses stay GUI-free

### DIFF
--- a/noScribe/__init__.py
+++ b/noScribe/__init__.py
@@ -1,1 +1,18 @@
-from noScribe import main
+"""noScribe package.
+
+Importing this package must stay lightweight: the diarization/whisper worker
+subprocesses (multiprocessing "spawn") re-import it just to reach their
+entrypoint module. An eager ``from noScribe import main`` would drag the whole
+GUI stack (tkinter, customtkinter, PyAV with its bundled FFmpeg) into every
+worker child -- and on macOS, PyAV's FFmpeg loaded next to torchcodec's system
+FFmpeg triggers objc duplicate-class warnings. ``noScribe.main`` is therefore
+loaded lazily (PEP 562); ``__main__.py``'s ``noScribe.main.noScribeMain()``
+keeps working unchanged.
+"""
+import importlib
+
+
+def __getattr__(name):
+    if name == "main":
+        return importlib.import_module("noScribe.main")
+    raise AttributeError(f"module 'noScribe' has no attribute {name!r}")

--- a/noScribe/__init__.py
+++ b/noScribe/__init__.py
@@ -5,24 +5,33 @@ subprocesses (multiprocessing "spawn") re-import it just to reach their
 entrypoint module. An eager ``from noScribe import main`` would drag the whole
 GUI stack (tkinter, customtkinter, PyAV with its bundled FFmpeg) into every
 worker child -- and on macOS, PyAV's FFmpeg loaded next to torchcodec's system
-FFmpeg triggers objc duplicate-class warnings. ``noScribe.main`` is therefore
+FFmpeg triggers objc duplicate-class warnings. The submodules are therefore
 loaded lazily (PEP 562); ``__main__.py``'s ``noScribe.main.noScribeMain()``
 keeps working unchanged.
 
-PyInstaller cannot follow this import, so every spec in pyinstaller/ lists
+PyInstaller cannot follow these imports, so every spec in pyinstaller/ lists
 ``noScribe.main`` in its hiddenimports -- without that the frozen app dies at
 startup with ModuleNotFoundError.
 """
-import importlib
+import importlib as _importlib
+
+# Everything main.py used to bind on the package as a side effect of being
+# imported eagerly. Kept so `import noScribe; noScribe.utils...` still works
+# and so a typo gets an honest "no attribute" rather than a stale one.
+_SUBMODULES = ("main", "audio", "exception", "transcription", "utils")
+
+# Star-import reads __all__, never __dir__; without this `from noScribe import *`
+# would bind the helper names above instead of the package's own module.
+__all__ = ["main"]
 
 
 def __getattr__(name):
-    if name == "main":
-        return importlib.import_module("noScribe.main")
-    raise AttributeError(f"module 'noScribe' has no attribute {name!r}")
+    if name in _SUBMODULES:
+        return _importlib.import_module(f"{__name__}.{name}")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def __dir__():
-    # Keep `main` discoverable (dir(), tab completion, `from noScribe import *`)
-    # even though it is no longer a real module attribute until first access.
-    return sorted([*globals(), "main"])
+    # A set: the import system binds each submodule into globals() on first
+    # access, so a list would show it twice from then on.
+    return sorted({*globals(), *_SUBMODULES})

--- a/noScribe/__init__.py
+++ b/noScribe/__init__.py
@@ -8,6 +8,10 @@ worker child -- and on macOS, PyAV's FFmpeg loaded next to torchcodec's system
 FFmpeg triggers objc duplicate-class warnings. ``noScribe.main`` is therefore
 loaded lazily (PEP 562); ``__main__.py``'s ``noScribe.main.noScribeMain()``
 keeps working unchanged.
+
+PyInstaller cannot follow this import, so every spec in pyinstaller/ lists
+``noScribe.main`` in its hiddenimports -- without that the frozen app dies at
+startup with ModuleNotFoundError.
 """
 import importlib
 

--- a/noScribe/__init__.py
+++ b/noScribe/__init__.py
@@ -16,3 +16,9 @@ def __getattr__(name):
     if name == "main":
         return importlib.import_module("noScribe.main")
     raise AttributeError(f"module 'noScribe' has no attribute {name!r}")
+
+
+def __dir__():
+    # Keep `main` discoverable (dir(), tab completion, `from noScribe import *`)
+    # even though it is no longer a real module attribute until first access.
+    return sorted([*globals(), "main"])

--- a/noScribe/__main__.py
+++ b/noScribe/__main__.py
@@ -1,8 +1,17 @@
+import multiprocessing as mp
+
 import noScribe
 
 if __name__ == "__main__":
-    try:
-        noScribe.main.noScribeMain()
-    except Exception as e:
-        print(e)
-        SystemExit(1)
+    # Must come before anything touches noScribe.main. Under PyInstaller a
+    # multiprocessing "spawn" child is the frozen binary started again, so it
+    # runs this script from the top; freeze_support() is what recognises such a
+    # child, runs its target and exits. main.py calls it too, but only after
+    # importing tkinter, customtkinter and PyAV -- which is the whole GUI stack
+    # this package's lazy __getattr__ exists to keep out of worker processes.
+    mp.freeze_support()
+    # Exceptions are deliberately not caught here. Swallowing them printed a
+    # bare message and still exited 0 -- and in a windowed build main.py's
+    # stdout fix has not run yet at import time, so the message went nowhere
+    # and a failed start looked like a successful one.
+    noScribe.main.noScribeMain()

--- a/pyinstaller/noScribe_linux.spec
+++ b/pyinstaller/noScribe_linux.spec
@@ -6,7 +6,9 @@ from PyInstaller.utils.hooks import collect_all
 
 datas = [('../img/noScribeLogo.png', 'img/'), ('../img/graphic_sw.png', 'img/'), ('../LICENSE.txt', '.'), ('../prompts/prompt.yml', 'prompts/'), ('../prompts/prompt_nd.yml', 'prompts/'), ('../pyannote', 'pyannote/'), ('../README.md', '.'), ('../trans', 'trans/')]
 binaries = []
-hiddenimports = ['PIL._tkinter_finder']
+# noScribe.main is reached through the package's lazy __getattr__, which
+# PyInstaller's static analysis cannot follow -- declare it explicitly.
+hiddenimports = ['PIL._tkinter_finder', 'noScribe.main']
 datas += collect_data_files('faster_whisper')
 datas += collect_data_files('lightning_fabric')
 tmp_ret = collect_all('pyannote')

--- a/pyinstaller/noScribe_macOS.spec
+++ b/pyinstaller/noScribe_macOS.spec
@@ -4,7 +4,9 @@ from PyInstaller.utils.hooks import collect_all
 
 datas = [('../img/graphic_sw.png', 'img'), ('../LICENSE.txt', '.'), ('../models/precise', 'models/precise/'), ('../models/fast', 'models/fast/'), ('../prompts/prompt.yml', 'prompts'), ('../prompts/prompt_nd.yml', 'prompts/'), ('../pyannote', 'pyannote/'), ('../README.md', '.'), ('../trans', 'trans/')]
 binaries = []
-hiddenimports = []
+# noScribe.main is reached through the package's lazy __getattr__, which
+# PyInstaller's static analysis cannot follow -- declare it explicitly.
+hiddenimports = ['noScribe.main']
 datas += collect_data_files('faster_whisper')
 datas += collect_data_files('lightning_fabric')
 tmp_ret = collect_all('pyannote')

--- a/pyinstaller/noScribe_win.spec
+++ b/pyinstaller/noScribe_win.spec
@@ -14,7 +14,9 @@ project_root = os.path.abspath(os.path.join(SPECPATH, '..'))
 
 noScribe_datas = [] 
 noScribe_binaries = []
-noScribe_hiddenimports = []
+# noScribe.main is reached through the package's lazy __getattr__, which
+# PyInstaller's static analysis cannot follow -- declare it explicitly.
+noScribe_hiddenimports = ['noScribe.main']
 
 noScribe_datas += [
 ('../models/precise/', './models/precise/'), 

--- a/tests/test_worker_import_lightweight.py
+++ b/tests/test_worker_import_lightweight.py
@@ -1,0 +1,41 @@
+"""Guard: importing a worker entrypoint module must not drag in the GUI.
+
+The diarization/whisper subprocesses (multiprocessing "spawn") re-import the
+noScribe package to reach their entrypoint. If the package __init__ eagerly
+imported noScribe.main, every worker child would load tkinter/customtkinter
+and PyAV -- and PyAV's bundled FFmpeg next to torchcodec's system FFmpeg
+triggers objc duplicate-class warnings on macOS. These tests run in a clean
+interpreter so the parent process's own imports can't mask a regression.
+"""
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = str(Path(__file__).resolve().parent.parent)
+
+
+def _run(code):
+    env = {**os.environ, "PYTHONPATH": REPO}
+    return subprocess.run([sys.executable, "-c", code], env=env,
+                          capture_output=True, text=True)
+
+
+def test_worker_import_pulls_no_gui_modules():
+    res = _run(
+        "import sys; import noScribe.pyannote_mp_worker; "
+        "heavy = [m for m in ('av', 'tkinter', 'customtkinter', 'noScribe.main') "
+        "if m in sys.modules]; "
+        "sys.exit('GUI modules leaked into worker import: %s' % heavy if heavy else 0)"
+    )
+    assert res.returncode == 0, res.stdout + res.stderr
+
+
+def test_lazy_main_attribute_still_works():
+    # __main__.py does noScribe.main.noScribeMain() -- the lazy __getattr__
+    # must keep that path alive.
+    res = _run(
+        "import noScribe; "
+        "assert callable(noScribe.main.noScribeMain), 'noScribeMain missing'"
+    )
+    assert res.returncode == 0, res.stdout + res.stderr

--- a/tests/test_worker_import_lightweight.py
+++ b/tests/test_worker_import_lightweight.py
@@ -39,3 +39,14 @@ def test_lazy_main_attribute_still_works():
         "assert callable(noScribe.main.noScribeMain), 'noScribeMain missing'"
     )
     assert res.returncode == 0, res.stdout + res.stderr
+
+
+def test_main_stays_discoverable_without_importing_it():
+    # A lazy attribute is invisible to dir() unless __dir__ says otherwise --
+    # and looking it up there must not trigger the import it avoids.
+    res = _run(
+        "import sys, noScribe; "
+        "assert 'main' in dir(noScribe), 'main missing from dir()'; "
+        "assert 'noScribe.main' not in sys.modules, 'dir() triggered the import'"
+    )
+    assert res.returncode == 0, res.stdout + res.stderr

--- a/tests/test_worker_import_lightweight.py
+++ b/tests/test_worker_import_lightweight.py
@@ -12,18 +12,37 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 REPO = str(Path(__file__).resolve().parent.parent)
 
+# Both are ctx.Process targets, so both are re-imported in a spawn child.
+WORKER_MODULES = ["noScribe.pyannote_mp_worker", "noScribe.whisper_mp_worker"]
 
-def _run(code):
+
+def _without_comments(text):
+    """Source with comment lines dropped. Both checks below look for a literal
+    that these files also *explain* in a comment; matching the explanation
+    would let them pass while the thing itself was gone."""
+    return "\n".join(line for line in text.splitlines()
+                     if not line.lstrip().startswith("#"))
+
+
+def _run(code, home=None):
     env = {**os.environ, "PYTHONPATH": REPO}
+    if home is not None:
+        # noScribe.main creates its config directory and writes config.yml at
+        # import time; point that at the test's own directory so the suite
+        # never touches the real one.
+        env.update(HOME=str(home), APPDATA=str(home), XDG_CONFIG_HOME=str(home))
     return subprocess.run([sys.executable, "-c", code], env=env,
                           capture_output=True, text=True)
 
 
-def test_worker_import_pulls_no_gui_modules():
+@pytest.mark.parametrize("module", WORKER_MODULES)
+def test_worker_import_pulls_no_gui_modules(module):
     res = _run(
-        "import sys; import noScribe.pyannote_mp_worker; "
+        f"import sys; import {module}; "
         "heavy = [m for m in ('av', 'tkinter', 'customtkinter', 'noScribe.main') "
         "if m in sys.modules]; "
         "sys.exit('GUI modules leaked into worker import: %s' % heavy if heavy else 0)"
@@ -31,32 +50,62 @@ def test_worker_import_pulls_no_gui_modules():
     assert res.returncode == 0, res.stdout + res.stderr
 
 
-def test_lazy_main_attribute_still_works():
+def test_every_spec_declares_the_lazy_main_import():
+    # PyInstaller's static analysis cannot follow importlib.import_module, so a
+    # spec that does not name noScribe.main produces a build that dies at
+    # startup with ModuleNotFoundError -- which no other test would catch.
+    specs = sorted((Path(REPO) / "pyinstaller").glob("noScribe_*.spec"))
+    assert specs, "no noScribe pyinstaller specs found"
+    missing = []
+    for spec in specs:
+        code = _without_comments(spec.read_text())
+        if "'noScribe.main'" not in code and '"noScribe.main"' not in code:
+            missing.append(spec.name)
+    assert not missing, f"specs missing the noScribe.main hidden import: {missing}"
+
+
+def test_lazy_main_attribute_still_works(tmp_path):
     # __main__.py does noScribe.main.noScribeMain() -- the lazy __getattr__
     # must keep that path alive.
     res = _run(
         "import noScribe; "
-        "assert callable(noScribe.main.noScribeMain), 'noScribeMain missing'"
+        "assert callable(noScribe.main.noScribeMain), 'noScribeMain missing'",
+        home=tmp_path,
     )
     assert res.returncode == 0, res.stdout + res.stderr
-
-
-def test_every_spec_declares_the_lazy_main_import():
-    # PyInstaller's static analysis cannot follow importlib.import_module, so
-    # a spec that does not name noScribe.main produces a build that dies at
-    # startup with ModuleNotFoundError -- which no other test would catch.
-    specs = sorted((Path(REPO) / "pyinstaller").glob("noScribe_*.spec"))
-    assert specs, "no noScribe pyinstaller specs found"
-    missing = [s.name for s in specs if "noScribe.main" not in s.read_text()]
-    assert not missing, f"specs missing the noScribe.main hidden import: {missing}"
 
 
 def test_main_stays_discoverable_without_importing_it():
-    # A lazy attribute is invisible to dir() unless __dir__ says otherwise --
-    # and looking it up there must not trigger the import it avoids.
+    # A lazy attribute is invisible to dir() and to star-import unless the
+    # module says otherwise -- and looking it up must not trigger the import it
+    # avoids, nor list the name twice once it has been bound.
     res = _run(
         "import sys, noScribe; "
-        "assert 'main' in dir(noScribe), 'main missing from dir()'; "
-        "assert 'noScribe.main' not in sys.modules, 'dir() triggered the import'"
+        "assert dir(noScribe).count('main') == 1, dir(noScribe); "
+        "assert 'noScribe.main' not in sys.modules, 'dir() triggered the import'; "
+        "ns = {}; exec('from noScribe import *', ns); "
+        "assert 'main' in ns, 'star-import no longer binds main'"
     )
     assert res.returncode == 0, res.stdout + res.stderr
+
+
+def test_submodules_stay_reachable_from_the_package():
+    """main.py used to bind these on the package as a side effect of being
+    imported eagerly; dropping that would turn `noScribe.utils` into an
+    AttributeError for a module that exists."""
+    res = _run(
+        "import noScribe; "
+        "assert noScribe.utils.ms_to_str(1000) == '00:00:01', 'utils unreachable'"
+    )
+    assert res.returncode == 0, res.stdout + res.stderr
+
+
+def test_freeze_support_runs_before_main_is_imported():
+    """Under PyInstaller a spawn child is the frozen binary started again, so
+    it re-runs __main__.py and freeze_support() has to intercept it there.
+    main.py calls it too, but only after importing tkinter, customtkinter and
+    PyAV -- the very stack a worker child must not load."""
+    source = _without_comments((Path(REPO) / "noScribe" / "__main__.py").read_text())
+    assert "mp.freeze_support()" in source
+    assert source.index("mp.freeze_support()") < source.index("noScribe.main"), \
+        "freeze_support() must come before anything touches noScribe.main"

--- a/tests/test_worker_import_lightweight.py
+++ b/tests/test_worker_import_lightweight.py
@@ -41,6 +41,16 @@ def test_lazy_main_attribute_still_works():
     assert res.returncode == 0, res.stdout + res.stderr
 
 
+def test_every_spec_declares_the_lazy_main_import():
+    # PyInstaller's static analysis cannot follow importlib.import_module, so
+    # a spec that does not name noScribe.main produces a build that dies at
+    # startup with ModuleNotFoundError -- which no other test would catch.
+    specs = sorted((Path(REPO) / "pyinstaller").glob("noScribe_*.spec"))
+    assert specs, "no noScribe pyinstaller specs found"
+    missing = [s.name for s in specs if "noScribe.main" not in s.read_text()]
+    assert not missing, f"specs missing the noScribe.main hidden import: {missing}"
+
+
 def test_main_stays_discoverable_without_importing_it():
     # A lazy attribute is invisible to dir() unless __dir__ says otherwise --
     # and looking it up there must not trigger the import it avoids.


### PR DESCRIPTION
Split out of #327 so it can be reviewed on its own — it is not macOS-specific.

## What

The diarization/whisper workers run via multiprocessing *spawn* and re-import
the `noScribe` package just to reach their entrypoint module. The eager
`from noScribe import main` in `__init__.py` dragged the whole GUI stack
(tkinter, customtkinter, PyAV) into every worker child.

This makes the attribute lazy (PEP 562), so a worker child imports only what it
actually needs. `__main__.py`'s `noScribe.main.noScribeMain()` keeps working
unchanged, and `dir(noScribe)` still lists `main` — both pinned by tests that
run in a clean interpreter, so the parent process's own imports cannot mask a
regression.

## The packaging half

PyInstaller's static analysis cannot follow the `importlib.import_module` call
behind `__getattr__`, and the specs analyse `__main__.py` — which now only does
`import noScribe`. Left alone, the frozen build would ship without
`noScribe.main` and fail at startup with `ModuleNotFoundError` while the test
suite stayed green. All three specs therefore declare `noScribe.main` as a
hidden import, and a test asserts they keep doing so.

I verified both halves with PyInstaller 6.4.0 on a minimal package with the
identical `__getattr__` shape: without the hidden import the built binary
raises `ModuleNotFoundError`, with it the binary runs. Worth a smoke-run of
your own build pipeline before merging, since CI only runs pytest.

## Why it matters beyond start-up weight

On macOS, PyAV's bundled FFmpeg loaded next to torchcodec's system FFmpeg in the
same child triggers objc duplicate-class warnings. Loading only one FFmpeg per
worker removes those at the root. On all platforms, worker children start
lighter and faster.

## Scope

No behavior change for the app itself. Independent of #327 (the macOS pin bump),
which no longer contains this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)