### PR TITLE
Build the code under review in the pyinstaller workflow

### DIFF
--- a/.github/workflows/pyinstaller.yml
+++ b/.github/workflows/pyinstaller.yml
@@ -1,12 +1,13 @@
 name: pyinstaller
 
 # Running on push events as well as on pull requests to ensure that merge
-# requests lead to a working pyinstaller build as well. However, only after the
-# pytest workflow succeeded.
-on:
-  workflow_run:
-    workflows: [pytest]
-    types: [completed]
+# requests lead to a working pyinstaller build as well.
+#
+# This has to be a direct trigger, not `workflow_run: [pytest]`. A workflow_run
+# job checks out the default branch, not the commit that triggered it, so the
+# build kept passing while it re-built main over and over -- a pull request
+# that breaks the build never got one of these runs against its own code.
+on: [push, pull_request]
 # TODO: change this in something like that after publishing the pyinstaller
 # builds from the CI directly to github releases.
 #on:


### PR DESCRIPTION
## The problem

The pyinstaller build smoke test has never run against a pull request.

`on: workflow_run` starts a job whose `actions/checkout` resolves to the
repository's **default branch**, not the commit that triggered the run. So the
workflow has been re-building `main` every time and reporting success.

Evidence from 2026-07-26 — eight runs, all triggered by pushes to five
different PR branches:

```
2026-07-26T16:51  workflow_run  branch=main  sha=dc4231e1  success
2026-07-26T16:50  workflow_run  branch=main  sha=dc4231e1  success
2026-07-26T15:24  workflow_run  branch=main  sha=dc4231e1  success
   ... (5 more, same sha)
```

Same commit every time, and `gh pr checks` on those PRs lists only
`pytest (3.10)` and `pytest (3.13)` — no pyinstaller check to gate on.

## Why it matters right now

#330 makes `noScribe.main` load lazily, which PyInstaller's static analysis
cannot follow. Without a hidden import the packaged app dies at startup with
`ModuleNotFoundError` while the whole test suite stays green. The
`./dist/noScribe/noScribe -h` step in this workflow is exactly the check that
catches that class of breakage — it just never saw the branch.

(#330 declares the hidden import, so it is fine; the point is that CI would
not have told either of us.)

## The change

Trigger the workflow directly, the same way `pytest.yml` does. One line, plus
a comment recording why it must not go back to `workflow_run`.

The trade-off is a build on a PR whose tests are failing. The
"only after pytest succeeded" ordering in the old comment cannot be expressed
across two workflows without giving up the correct checkout — if the build
minutes matter more than the isolation, the alternative is moving the job into
`pytest.yml` with `needs: pytest`, which keeps both. Happy to switch to that
if you prefer it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)