### PR TITLE
Break the line before an in-paragraph timestamp

### DIFF
--- a/noScribe/main.py
+++ b/noScribe/main.py
@@ -2815,16 +2815,27 @@ class App(ctk.CTk):
                             else: # same speaker
                                 if job.timestamps:
                                     if (start - last_timestamp_ms) > job.timestamp_interval:
-                                        seg_html = f' <span style=\"color: {job.timestamp_color}\" >{ts}</span>{html.escape(seg_text, quote=False)}'
-                                        seg_text = f' {ts}{seg_text}'
+                                        # Break the line first: a speaker who holds
+                                        # the floor for many minutes stays in one
+                                        # paragraph, so without this the timestamps
+                                        # accumulate into a single unreadable line.
+                                        seg_html = f'<br><span style=\"color: {job.timestamp_color}\" >{ts}</span>{html.escape(seg_text, quote=False)}'
+                                        seg_text = f'\n{ts}{seg_text}'
                                         last_timestamp_ms = start
                                     else:
                                         seg_html = html.escape(seg_text, quote=False)
 
                         else: # no speaker detection
                             if job.timestamps and (first_segment or (start - last_timestamp_ms) > job.timestamp_interval):
-                                seg_html = f' <span style=\"color: {job.timestamp_color}\" >{ts}</span>{html.escape(seg_text, quote=False)}'
-                                seg_text = f' {ts}{seg_text}'
+                                # Same reasoning as above -- and with no speaker
+                                # detection there are no paragraph breaks at all,
+                                # so this is the only thing keeping the transcript
+                                # from being one line. Not before the first
+                                # segment, which would open the text with a blank
+                                # line (the lstrip below only handles spaces).
+                                br, nl = ('', '') if first_segment else ('<br>', '\n')
+                                seg_html = f'{br}<span style=\"color: {job.timestamp_color}\" >{ts}</span>{html.escape(seg_text, quote=False)}'
+                                seg_text = f'{nl}{ts}{seg_text}'
                                 last_timestamp_ms = start
                             else:
                                 seg_html = html.escape(seg_text, quote=False)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -389,3 +389,24 @@ class TestApostropheFix:
         d = self._build_doc_with_text("a < b & c > d")
         txt_out = utils.html_to_text(d.asHTML(), use_only_body=True)
         assert txt_out == "a < b & c > d"
+
+
+def test_timestamp_line_break_survives_the_exports():
+    """A speaker holding the floor stays in one paragraph, so the transcript
+    puts a <br> before each in-paragraph timestamp to keep the line readable.
+    Both export paths have to cope with that break sitting inside the anchor:
+    the text export turns it into a newline, and it must not leak into a VTT
+    cue, where a line break would split the caption.
+    """
+    seg = ('<a name="ts_1000_2000_S01" >S01: Erster Teil der Rede.</a>'
+           '<a name="ts_61000_62000_S01" ><br>'
+           '<span style="color: #78909C" >[00:01:01]</span>Zweiter Teil.</a>')
+    doc = f'<html><body><p>Titel</p><p>Info</p><p>{seg}</p></body></html>'
+
+    text = utils.html_to_text(doc)
+    assert "Rede.\n[00:01:01] Zweiter Teil." in text
+
+    vtt = utils.html_to_webvtt(doc)
+    assert "<v S01>Zweiter Teil." in vtt      # timestamp and break both stripped
+    assert "<br>" not in vtt
+    assert "[00:01:01]" not in vtt


### PR DESCRIPTION
## The problem

A new paragraph is only started when the speaker changes. With timestamps
enabled, a speaker who holds the floor for twenty minutes therefore produces a
single paragraph with a timestamp every minute and no line break anywhere — one
line, thousands of characters long. Without speaker detection there are no
paragraph breaks at all, so the entire transcript is one line.

Noticed on a five-hour group session: the affected paragraph ran past 4000
characters.

## The change

Put a `<br>` in front of the timestamp when it is inserted inside an existing
paragraph — both in the same-speaker branch and in the no-speaker-detection
branch. Not before the very first segment, where it would open the transcript
with a blank line.

The exports already cope with a `<br>` inside the `ts_` anchor, which I checked
before relying on it:

- `utils.html_to_text` turns it into a newline (`handle_starttag` already
  treats `br` like a block element),
- `utils.html_to_webvtt` strips it along with the timestamp span rather than
  splitting the cue.

Both are now pinned by a test. The code that writes the anchor lives inside the
GUI transcription loop and is not reachable from a test, so the test covers the
contract that makes the change safe rather than the line itself.

## Scope

Display only — no change to timing, segmentation or the anchors that drive
audio sync. Independent of the other open PRs; it touches `on_segment`, which
#323 also edits, but in a different branch of that function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)