### PR TITLE
Log the job traceback only for real errors, so a user cancel no longer shows up in the log as a crash

### DIFF
--- a/noScribe/main.py
+++ b/noScribe/main.py
@@ -2288,14 +2288,18 @@ class App(ctk.CTk):
                     # Distinguish cancellation from real errors
                     error_msg = job.error_message or str(e)
                     if str(e) == t('err_user_cancelation') or self.cancel:
+                        # A user cancel is not an error: log the plain message,
+                        # not a traceback that makes it look like a crash.
                         job.set_canceled(t('err_user_cancelation'))
+                        self.update_queue_table()
+                        self.logn(t('err_user_cancelation'), 'error')
                     else:
                         job.set_error(error_msg)
-                    self.update_queue_table()
-                    self.logn(error_msg, 'error')
-                    traceback_str = job.error_tb or traceback.format_exc()
-                    self.logn(f"Job error details: {traceback_str}", where='file')
-                    print(f"Job error details: {traceback_str}")
+                        self.update_queue_table()
+                        self.logn(error_msg, 'error')
+                        traceback_str = job.error_tb or traceback.format_exc()
+                        self.logn(f"Job error details: {traceback_str}", where='file')
+                        print(f"Job error details: {traceback_str}")
                 finally:
                     # If we were canceling only the current job, reset flags after it stops
                     if self._cancel_job_only:


### PR DESCRIPTION
When the user cancels a running transcription, the cancel is transported out of the queue-pump loop as an exception. The job-level handler already distinguishes it from real errors (the job is counted as canceled, not failed), but it then unconditionally logged the message as an error followed by `Job error details:` with a full traceback — so a deliberate cancel looked like a crash in the log file and on stdout.

This splits the handler: a user cancel now logs only the cancellation message, while real errors keep the full error message and traceback exactly as before.

Observed log before the change (user cancel):

```
Job error details: Traceback (most recent call last):
  ...
  File "noScribe/main.py", line 3566, in _run_engine_subprocess_stream
    raise Exception(t('err_user_cancelation'))
Exception: <localized user-cancel message>
```

The summary at the end was already correct (canceled: 1, failed: 0); only the logging changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)